### PR TITLE
Refactor daily learning config to use centralized mapping

### DIFF
--- a/src/deserializeDownload.js
+++ b/src/deserializeDownload.js
@@ -1,4 +1,17 @@
 import DownloadProtoBuf from './download_pb.cjs';
+import {dailyLearningConfig} from './urlArgs.js';
+
+/**
+ * Transforms a protocName (e.g. "shemiratHaLashon") into the capitalized
+ * suffix used by the protobuf library (e.g. "Shemirathalashon"), so that
+ * getter/setter method names can be constructed dynamically.
+ * @param {string} protocName
+ * @return {string}
+ */
+function protocNameToMethodSuffix(protocName) {
+  const lower = protocName.toLowerCase();
+  return lower.charAt(0).toUpperCase() + lower.slice(1);
+}
 
 /**
  * @param {string} data
@@ -46,33 +59,18 @@ export function deserializeDownload(data) {
   q.subscribe = msg.getSubscribe() ? '1' : undefined;
   q.ny = msg.getNumyears() || undefined;
   q.zip = msg.getZip() || undefined;
-  if (msg.getSedrot()) q.s = 'on';
   if (msg.getOmer()) q.o = 'on';
-  if (msg.getDafyomi()) q.F = 'on';
-  if (msg.getMishnayomi()) q.myomi = 'on';
-  if (msg.getPerekyomi()) q.dpy = 'on';
-  if (msg.getNachyomi()) q.nyomi = 'on';
   if (msg.getAddaltdates()) q.d = 'on';
   if (msg.getAddaltdatesforevents()) q.D = 'on';
   if (msg.getYomkippurkatan()) q.ykk = 'on';
-  if (msg.getYerushalmiyomi()) q.yyomi = 'on';
-  if (msg.getYyschottenstein()) q.yys = 'on';
-  if (msg.getRambam1()) q.dr1 = 'on';
-  if (msg.getRambam3()) q.dr3 = 'on';
-  if (msg.getSeferhamitzvot()) q.dsm = 'on';
-  if (msg.getKitzurshulchanaruch()) q.dksa = 'on';
-  if (msg.getChofetzchaim()) q.dcc = 'on';
-  if (msg.getShemirathalashon()) q.dshl = 'on';
-  if (msg.getDafweekly()) q.dw = 'on';
-  if (msg.getPsalms()) q.dps = 'on';
-  if (msg.getTanakhyomi()) q.dty = 'on';
-  if (msg.getPirkeiavotsummer()) q.dpa = 'on';
-  if (msg.getArukhhashulchanyomi()) q.ahsy = 'on';
+  for (const {queryParam, protocName} of dailyLearningConfig) {
+    const suffix = protocNameToMethodSuffix(protocName);
+    if (msg[`get${suffix}`]()) q[queryParam] = 'on';
+  }
   if (msg.getUseelevation()) q.ue = 'on';
   if (msg.getYizkor()) q.yzkr = 'on';
   if (msg.getShabbatmevarchim()) q.mvch = 'on';
   q.mm = String(msg.getMonthmode());
-  if (msg.getDirshuamudyomi()) q.ayd = 'on';
   if (msg.getYomtovonly()) q.yto = 'on';
   q.month = msg.getMonth() || undefined;
   if (msg.getGeopos()) {

--- a/src/deserializeDownload.js
+++ b/src/deserializeDownload.js
@@ -1,17 +1,5 @@
 import DownloadProtoBuf from './download_pb.cjs';
-import {dailyLearningConfig} from './urlArgs.js';
-
-/**
- * Transforms a protocName (e.g. "shemiratHaLashon") into the capitalized
- * suffix used by the protobuf library (e.g. "Shemirathalashon"), so that
- * getter/setter method names can be constructed dynamically.
- * @param {string} protocName
- * @return {string}
- */
-function protocNameToMethodSuffix(protocName) {
-  const lower = protocName.toLowerCase();
-  return lower.charAt(0).toUpperCase() + lower.slice(1);
-}
+import {dailyLearningConfig, protocNameToMethodSuffix} from './urlArgs.js';
 
 /**
  * @param {string} data

--- a/src/makeDownloadProps.js
+++ b/src/makeDownloadProps.js
@@ -1,21 +1,9 @@
 import {getDownloadFilename, makeAnchor} from '@hebcal/rest-api';
 import {basename} from 'node:path';
 import {empty, off} from './empty.js';
-import {urlArgsObj, dailyLearningConfig} from './urlArgs.js';
+import {urlArgsObj, dailyLearningConfig, protocNameToMethodSuffix} from './urlArgs.js';
 import {isoDateStringToDate} from './dateUtil.js';
 import DownloadProtoBuf from './download_pb.cjs';
-
-/**
- * Transforms a protocName (e.g. "shemiratHaLashon") into the capitalized
- * suffix used by the protobuf library (e.g. "Shemirathalashon"), so that
- * getter/setter method names can be constructed dynamically.
- * @param {string} protocName
- * @return {string}
- */
-function protocNameToMethodSuffix(protocName) {
-  const lower = protocName.toLowerCase();
-  return lower.charAt(0).toUpperCase() + lower.slice(1);
-}
 
 const dlPrefix = process.env.NODE_ENV == 'production' ?
   'https://download.hebcal.com' : 'http://127.0.0.1:8081';

--- a/src/makeDownloadProps.js
+++ b/src/makeDownloadProps.js
@@ -1,9 +1,21 @@
 import {getDownloadFilename, makeAnchor} from '@hebcal/rest-api';
 import {basename} from 'node:path';
 import {empty, off} from './empty.js';
-import {urlArgsObj} from './urlArgs.js';
+import {urlArgsObj, dailyLearningConfig} from './urlArgs.js';
 import {isoDateStringToDate} from './dateUtil.js';
 import DownloadProtoBuf from './download_pb.cjs';
+
+/**
+ * Transforms a protocName (e.g. "shemiratHaLashon") into the capitalized
+ * suffix used by the protobuf library (e.g. "Shemirathalashon"), so that
+ * getter/setter method names can be constructed dynamically.
+ * @param {string} protocName
+ * @return {string}
+ */
+function protocNameToMethodSuffix(protocName) {
+  const lower = protocName.toLowerCase();
+  return lower.charAt(0).toUpperCase() + lower.slice(1);
+}
 
 const dlPrefix = process.env.NODE_ENV == 'production' ?
   'https://download.hebcal.com' : 'http://127.0.0.1:8081';
@@ -77,27 +89,14 @@ export function downloadHref2(query, filename, override={}) {
   if (ny !== null) msg.setNumyears(ny);
   if (!empty(q.zip)) msg.setZip(q.zip);
 
-  if (on(q.s)) msg.setSedrot(true);
   if (on(q.o)) msg.setOmer(true);
-  if (on(q.F)) msg.setDafyomi(true);
-  if (on(q.myomi)) msg.setMishnayomi(true);
-  if (on(q.dpy)) msg.setPerekyomi(true);
-  if (on(q.nyomi)) msg.setNachyomi(true);
   if (on(q.ykk)) msg.setYomkippurkatan(true);
-  if (on(q.yyomi)) msg.setYerushalmiyomi(true);
-  if (on(q.yys)) msg.setYyschottenstein(true);
-  if (on(q.dr1)) msg.setRambam1(true);
-  if (on(q.dr3)) msg.setRambam3(true);
-  if (on(q.dsm)) msg.setSeferhamitzvot(true);
-  if (on(q.dksa)) msg.setKitzurshulchanaruch(true);
-  if (on(q.dcc)) msg.setChofetzchaim(true);
-  if (on(q.dshl)) msg.setShemirathalashon(true);
-  if (on(q.dps)) msg.setPsalms(true);
-  if (on(q.dw)) msg.setDafweekly(true);
-  if (on(q.ayd)) msg.setDirshuamudyomi(true);
-  if (on(q.dty)) msg.setTanakhyomi(true);
-  if (on(q.dpa)) msg.setPirkeiavotsummer(true);
-  if (on(q.ahsy)) msg.setArukhhashulchanyomi(true);
+  for (const {queryParam, protocName} of dailyLearningConfig) {
+    if (on(q[queryParam])) {
+      const suffix = protocNameToMethodSuffix(protocName);
+      msg[`set${suffix}`](true);
+    }
+  }
   if (on(q.yzkr)) msg.setYizkor(true);
   if (on(q.mvch)) msg.setShabbatmevarchim(true);
 

--- a/src/urlArgs.js
+++ b/src/urlArgs.js
@@ -4,6 +4,18 @@ import {readJSON} from './readJSON.js';
 
 export const dailyLearningConfig = readJSON('./dailyLearningConfig.json');
 
+/**
+ * Transforms a protocName (e.g. "shemiratHaLashon") into the capitalized
+ * suffix used by the protobuf library (e.g. "Shemirathalashon"), so that
+ * getter/setter method names can be constructed dynamically.
+ * @param {string} protocName
+ * @return {string}
+ */
+export function protocNameToMethodSuffix(protocName) {
+  const lower = protocName.toLowerCase();
+  return lower.charAt(0).toUpperCase() + lower.slice(1);
+}
+
 export const DEFAULT_CANDLE_MINS = 18;
 
 export const hebcalFormDefaults = {


### PR DESCRIPTION
## Summary
Refactored the daily learning feature handling to use a centralized configuration mapping instead of repetitive conditional statements. This reduces code duplication and makes it easier to maintain and extend daily learning options.

## Key Changes
- Extracted a new `protocNameToMethodSuffix()` utility function to dynamically construct protobuf method names from protocol names
- Imported `dailyLearningConfig` from `urlArgs.js` in both `makeDownloadProps.js` and `deserializeDownload.js`
- Replaced 16 individual conditional statements for daily learning options with a single loop that iterates over `dailyLearningConfig`
- Removed hardcoded mappings for: Sedrot, Daf Yomi, Mishnayomi, Perek Yomi, Nach Yomi, Yerushalmi Yomi, Yeshiva Schottenstein, Rambam 1 & 3, Sefer Hamitzvot, Kitzur Shulchan Aruch, Chofetz Chaim, Shemirat Halashon, Psalms, Daf Weekly, Dirshau Amud Yomi, Tanakh Yomi, Pirkei Avot Summer, and Arukh Hashulchan Yomi

## Implementation Details
- The `protocNameToMethodSuffix()` function converts camelCase protocol names (e.g., "shemiratHaLashon") to the capitalized format expected by protobuf getters/setters (e.g., "Shemirathalashon")
- Both files now use the same configuration source, ensuring consistency between serialization and deserialization
- The refactored code is more maintainable—adding new daily learning options only requires updating the centralized `dailyLearningConfig` array

https://claude.ai/code/session_017VDhr1hRsYNhgk9qGSQzrx