### PR TITLE
Add undocumented tzeit=<degrees> URL parameter for havdalahDeg

### DIFF
--- a/src/calendar.js
+++ b/src/calendar.js
@@ -132,6 +132,18 @@ export function makeHebcalOptions(db, query) {
       }
     }
   }
+  // Undocumented tzeit=<degrees> overrides M=on (8.5 degrees) or m=<minutes>
+  // See https://github.com/hebcal/hebcal/issues/308
+  if (!empty(query.tzeit)) {
+    const deg = parseFloat(query.tzeit);
+    if (!isNaN(deg)) {
+      options.havdalahDeg = deg;
+      delete options.havdalahMins;
+      delete query.m;
+    } else {
+      delete query.tzeit;
+    }
+  }
   // force numYears to be >= 1 and <= 10, but only if explicitly specified
   if (typeof options.numYears === 'number') {
     options.numYears = getNumYears(options);

--- a/src/deserializeDownload.js
+++ b/src/deserializeDownload.js
@@ -20,6 +20,10 @@ export function deserializeDownload(data) {
   if (q.M === 'off') {
     q.m = msg.getHavdalahmins();
   }
+  const tzeit = msg.getTzeit();
+  if (tzeit !== 0) {
+    q.tzeit = tzeit;
+  }
   q.yt = msg.getIshebrewyear() ? 'H' : 'G';
   if (msg.getCandlelighting()) q.c = 'on';
   q.geonameid = msg.getGeonameid() || undefined;

--- a/src/download.proto
+++ b/src/download.proto
@@ -87,4 +87,5 @@ message Download {
   MonthMode monthMode = 64;
   bool yomTovOnly = 65;
   bool dirshuAmudYomi = 66;
+  float tzeit = 67;
 }

--- a/src/download_pb.cjs
+++ b/src/download_pb.cjs
@@ -217,7 +217,8 @@ proto.Download.toObject = function(includeInstance, msg) {
     kitzurshulchanaruch: jspb.Message.getBooleanFieldWithDefault(msg, 63, false),
     monthmode: jspb.Message.getFieldWithDefault(msg, 64, 0),
     yomtovonly: jspb.Message.getBooleanFieldWithDefault(msg, 65, false),
-    dirshuamudyomi: jspb.Message.getBooleanFieldWithDefault(msg, 66, false)
+    dirshuamudyomi: jspb.Message.getBooleanFieldWithDefault(msg, 66, false),
+    tzeit: jspb.Message.getFloatingPointFieldWithDefault(msg, 67, 0.0)
   };
 
   if (includeInstance) {
@@ -505,6 +506,10 @@ proto.Download.deserializeBinaryFromReader = function(msg, reader) {
     case 66:
       var value = /** @type {boolean} */ (reader.readBool());
       msg.setDirshuamudyomi(value);
+      break;
+    case 67:
+      var value = /** @type {number} */ (reader.readFloat());
+      msg.setTzeit(value);
       break;
     default:
       reader.skipField();
@@ -973,6 +978,13 @@ proto.Download.serializeBinaryToWriter = function(message, writer) {
   if (f) {
     writer.writeBool(
       66,
+      f
+    );
+  }
+  f = message.getTzeit();
+  if (f !== 0.0) {
+    writer.writeFloat(
+      67,
       f
     );
   }
@@ -2272,6 +2284,24 @@ proto.Download.prototype.getDirshuamudyomi = function() {
  */
 proto.Download.prototype.setDirshuamudyomi = function(value) {
   return jspb.Message.setProto3BooleanField(this, 66, value);
+};
+
+
+/**
+ * optional float tzeit = 67;
+ * @return {number}
+ */
+proto.Download.prototype.getTzeit = function() {
+  return /** @type {number} */ (jspb.Message.getFloatingPointFieldWithDefault(this, 67, 0.0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.Download} returns this
+ */
+proto.Download.prototype.setTzeit = function(value) {
+  return jspb.Message.setProto3FloatField(this, 67, value);
 };
 
 

--- a/src/makeDownloadProps.js
+++ b/src/makeDownloadProps.js
@@ -63,6 +63,10 @@ export function downloadHref2(query, filename, override={}) {
   const m = getInt(q.m);
   if (m !== null) msg.setHavdalahmins(m);
   if (q.M === 'on' || m === null) msg.setHavdalahtzeit(true);
+  if (!empty(q.tzeit)) {
+    const tzeit = parseFloat(q.tzeit);
+    if (!isNaN(tzeit)) msg.setTzeit(tzeit);
+  }
   const b = getInt(q.b);
   if (b !== null) msg.setCandlelightingmins(b);
   if (on(q.emoji) || q.emoji === true) {

--- a/test/calendar.test.js
+++ b/test/calendar.test.js
@@ -1,0 +1,40 @@
+import {describe, it, expect} from 'vitest';
+import {makeHebcalOptions} from '../src/calendar.js';
+
+// https://github.com/hebcal/hebcal/issues/308
+describe('makeHebcalOptions tzeit parameter', () => {
+  it('sets havdalahDeg from tzeit=16.1', () => {
+    const query = {year: '2026', tzeit: '16.1'};
+    const options = makeHebcalOptions(null, query);
+    expect(options.havdalahDeg).toBeCloseTo(16.1, 5);
+    expect(options.havdalahMins).toBeUndefined();
+  });
+
+  it('tzeit overrides M=on (which would imply 8.5 degrees)', () => {
+    const query = {year: '2026', M: 'on', tzeit: '7.083'};
+    const options = makeHebcalOptions(null, query);
+    expect(options.havdalahDeg).toBeCloseTo(7.083, 5);
+    expect(options.havdalahMins).toBeUndefined();
+  });
+
+  it('tzeit overrides m=<minutes>', () => {
+    const query = {year: '2026', m: '50', tzeit: '10.5'};
+    const options = makeHebcalOptions(null, query);
+    expect(options.havdalahDeg).toBeCloseTo(10.5, 5);
+    expect(options.havdalahMins).toBeUndefined();
+    expect(query.m).toBeUndefined();
+  });
+
+  it('ignores invalid tzeit value', () => {
+    const query = {year: '2026', M: 'on', tzeit: 'not-a-number'};
+    const options = makeHebcalOptions(null, query);
+    expect(options.havdalahDeg).toBe(8.5);
+    expect(query.tzeit).toBeUndefined();
+  });
+
+  it('M=on without tzeit preserves 8.5 degrees default', () => {
+    const query = {year: '2026', M: 'on'};
+    const options = makeHebcalOptions(null, query);
+    expect(options.havdalahDeg).toBe(8.5);
+  });
+});

--- a/test/download.test.js
+++ b/test/download.test.js
@@ -185,6 +185,47 @@ describe('Dirshu Amud HaYomi protobuf round-trip', () => {
   });
 });
 
+// https://github.com/hebcal/hebcal/issues/308
+describe('tzeit protobuf round-trip', () => {
+  it('should serialize and deserialize tzeit correctly', () => {
+    const query = {
+      v: '1',
+      maj: 'on',
+      year: '2026',
+      geonameid: '281184',
+      lg: 's',
+      tzeit: '16.1',
+    };
+    const href = downloadHref2(query, 'test.ics');
+    const match = href.match(/\/v4\/([^/]+)\//);
+    expect(match).toBeTruthy();
+    const encoded = match[1]
+        .replace(/-/g, '+')
+        .replace(/_/g, '/');
+    const result = deserializeDownload(encoded);
+    expect(typeof result.tzeit).toBe('number');
+    expect(result.tzeit).toBeCloseTo(16.1, 4);
+  });
+
+  it('should not include tzeit when not set', () => {
+    const query = {
+      v: '1',
+      maj: 'on',
+      year: '2026',
+      geonameid: '281184',
+      lg: 's',
+      M: 'on',
+    };
+    const href = downloadHref2(query, 'test.ics');
+    const match = href.match(/\/v4\/([^/]+)\//);
+    const encoded = match[1]
+        .replace(/-/g, '+')
+        .replace(/_/g, '/');
+    const result = deserializeDownload(encoded);
+    expect(result.tzeit).toBeUndefined();
+  });
+});
+
 describe('304 Not Modified (ETag / If-None-Match)', () => {
   it('returns 304 for ICS when If-None-Match matches ETag', async () => {
     const icsPath = '/v4/CAEQARgBIAEoATABOAFQAVjglBFqAXNwMngomAEBoAEB/hebcal_Jerusalem.ics';


### PR DESCRIPTION
Introduces a new URL parameter tzeit=<decimal-degrees> (e.g. tzeit=16.1)
that sets options.havdalahDeg in makeHebcalOptions. When specified, it
overrides the M URL parameter (equivalent to tzeit=8.5) and the m URL
parameter (minutes past sundown).

Adds float tzeit = 67 to download.proto and wires it through
deserializeDownload and downloadHref2 so the field survives round-trips
through download URLs.

Undocumented JSON-API-only feature; no EJS template changes.

See https://github.com/hebcal/hebcal/issues/308