### PR TITLE
Add truncation notice to ICS feeds exceeding event limit

### DIFF
--- a/src/hebcal-download.js
+++ b/src/hebcal-download.js
@@ -20,7 +20,7 @@ function makeTruncationNoticeEvent(lastEvent) {
   const ev = new Event(noticeDate, 'Hebcal calendar feed truncated', flags.USER_EVENT);
   ev.alarm = false;
   ev.memo = 'Your Hebcal calendar subscription exceeded the maximum number of events and has been truncated. ' +
-    'To see additional events, visit https://www.hebcal.com/';
+    'Visit https://www.hebcal.com/home/1398/number-of-years-in-calendar-feed-subscriptions to learn more about the feed length limit.';
   return ev;
 }
 

--- a/src/hebcal-download.js
+++ b/src/hebcal-download.js
@@ -36,7 +36,7 @@ export function limitIcsFeedLength(events, isSubscription, today) {
     const filteredEvts = events.filter((ev) => ev.getDate().abs() >= startAbs);
     if (filteredEvts.length > maxEventsIcsSub) {
       const truncated = filteredEvts.slice(0, maxEventsIcsSub);
-      truncated.push(makeTruncationNoticeEvent(truncated[truncated.length - 1]));
+      truncated.push(makeTruncationNoticeEvent(truncated.at(-1)));
       return truncated;
     }
     return filteredEvts;

--- a/src/hebcal-download.js
+++ b/src/hebcal-download.js
@@ -13,7 +13,16 @@ import {makeIcalOpts} from './urlArgs.js';
 import {addIcalParshaMemo, addCsvParshaMemo} from './parshaCommon.js';
 import {murmur128HexSync} from 'murmurhash3';
 
-const maxEventsIcsSub = 2400;
+export const maxEventsIcsSub = 2399;
+
+function makeTruncationNoticeEvent(lastEvent) {
+  const noticeDate = lastEvent.getDate().next();
+  const ev = new Event(noticeDate, 'Hebcal calendar feed truncated', flags.USER_EVENT);
+  ev.alarm = false;
+  ev.memo = 'Your Hebcal calendar subscription exceeded the maximum number of events and has been truncated. ' +
+    'To see additional events, visit https://www.hebcal.com/';
+  return ev;
+}
 
 /**
  * @param {Event[]} events
@@ -21,12 +30,14 @@ const maxEventsIcsSub = 2400;
  * @param {HDate} today
  * @return {Event[]}
  */
-function limitIcsFeedLength(events, isSubscription, today) {
+export function limitIcsFeedLength(events, isSubscription, today) {
   if (isSubscription && events.length > maxEventsIcsSub) {
     const startAbs = today.abs() - 12 * 7; // 12 weeks ago;
     const filteredEvts = events.filter((ev) => ev.getDate().abs() >= startAbs);
     if (filteredEvts.length > maxEventsIcsSub) {
-      return filteredEvts.slice(0, maxEventsIcsSub);
+      const truncated = filteredEvts.slice(0, maxEventsIcsSub);
+      truncated.push(makeTruncationNoticeEvent(truncated[truncated.length - 1]));
+      return truncated;
     }
     return filteredEvts;
   }

--- a/test/download.test.js
+++ b/test/download.test.js
@@ -303,8 +303,8 @@ describe('limitIcsFeedLength truncation notice', () => {
     const today = new HDate(new Date(year, 0, 1));
     const limited = limitIcsFeedLength(events, true, today);
     expect(limited.length).toBe(maxEventsIcsSub + 1);
-    const lastEvent = limited[limited.length - 1];
-    const prevEvent = limited[limited.length - 2];
+    const lastEvent = limited.at(-1);
+    const prevEvent = limited.at(-2);
     expect(lastEvent.render()).toContain('truncated');
     expect(lastEvent.getDate().abs()).toBe(prevEvent.getDate().abs() + 1);
   });

--- a/test/download.test.js
+++ b/test/download.test.js
@@ -1,9 +1,12 @@
 import {describe, it, expect, beforeAll} from 'vitest';
 import request from 'supertest';
+import {HDate, HebrewCalendar} from '@hebcal/core';
+import '@hebcal/learning';
 import {app} from '../src/app-download.js';
 import {MockMysqlDb} from './mock-mysql.js';
 import {downloadHref2} from '../src/makeDownloadProps.js';
 import {deserializeDownload} from '../src/deserializeDownload.js';
+import {limitIcsFeedLength, maxEventsIcsSub} from '../src/hebcal-download.js';
 
 beforeAll(() => {
   app.context.mysql = new MockMysqlDb();
@@ -268,5 +271,52 @@ describe('304 Not Modified (ETag / If-None-Match)', () => {
         .set('If-None-Match', etag);
     expect(second.status).toBe(304);
     expect(second.text).toBeFalsy();
+  });
+});
+
+describe('limitIcsFeedLength truncation notice', () => {
+  it('appends a synthetic truncation notice when feed exceeds the limit', () => {
+    const year = 2024;
+    const events = HebrewCalendar.calendar({
+      year,
+      isHebrewYear: false,
+      noHolidays: true,
+      dailyLearning: {
+        dafYomi: true,
+        mishnaYomi: true,
+        perekYomi: true,
+        nachYomi: true,
+        tanakhYomi: true,
+        psalms: true,
+        rambam1: true,
+        rambam3: true,
+        seferHaMitzvot: true,
+        'yerushalmi-vilna': true,
+        chofetzChaim: true,
+        shemiratHaLashon: true,
+        dirshuAmudYomi: true,
+        arukhHaShulchanYomi: true,
+        kitzurShulchanAruch: true,
+      },
+    });
+    expect(events.length).toBeGreaterThan(maxEventsIcsSub);
+    const today = new HDate(new Date(year, 0, 1));
+    const limited = limitIcsFeedLength(events, true, today);
+    expect(limited.length).toBe(maxEventsIcsSub + 1);
+    const lastEvent = limited[limited.length - 1];
+    const prevEvent = limited[limited.length - 2];
+    expect(lastEvent.render()).toContain('truncated');
+    expect(lastEvent.getDate().abs()).toBe(prevEvent.getDate().abs() + 1);
+  });
+
+  it('returns events unchanged when below the limit', () => {
+    const events = HebrewCalendar.calendar({
+      year: 2024,
+      isHebrewYear: false,
+    });
+    expect(events.length).toBeLessThan(maxEventsIcsSub);
+    const today = new HDate(new Date(2024, 0, 1));
+    const limited = limitIcsFeedLength(events, true, today);
+    expect(limited).toBe(events);
   });
 });


### PR DESCRIPTION
## Summary
When an ICS calendar subscription exceeds the maximum event limit (2399 events), a synthetic truncation notice event is now appended to inform users that their feed has been truncated.

## Changes
- **Export `maxEventsIcsSub` and `limitIcsFeedLength`** from `hebcal-download.js` to make them testable
- **Reduce `maxEventsIcsSub`** from 2400 to 2399 to accommodate the truncation notice event
- **Add `makeTruncationNoticeEvent()`** helper function that creates a synthetic event on the day after the last event, with a memo explaining the truncation and linking to documentation
- **Update `limitIcsFeedLength()`** to append the truncation notice when a subscription feed is truncated
- **Add comprehensive test coverage** in `test/download.test.js`:
  - Test that truncation notice is appended when feed exceeds limit (with 16 daily learning sources to generate >2400 events)
  - Test that events remain unchanged when below the limit

## Implementation Details
The truncation notice is a `USER_EVENT` with `alarm: false` that appears on the day after the last included event. This provides users with clear feedback that their calendar feed has been limited and directs them to learn more about the subscription limits.

https://claude.ai/code/session_01VbrAex3RdepesbV26N1htZ