### PR TITLE
Fix yahrzeit "day before" reminder checkbox on alt download button

### DIFF
--- a/test/download.test.js
+++ b/test/download.test.js
@@ -144,6 +144,37 @@ describe('v3 yahrzeit subscription downloads', () => {
     expect(response.text).toContain('BEGIN:VCALENDAR');
     expect(response.text).toContain('Golda Meir');
   });
+
+  it('includes day-before reminder events by default', async () => {
+    const response = await request(app.callback())
+        .get('/v3/01jthv2t5k88yermamssn96pzf/golda_meir.ics');
+    expect(response.status).toBe(200);
+    expect(response.text).toContain('Golda Meir Yahrzeit reminder');
+  });
+
+  it('omits day-before reminder events when yrem=0', async () => {
+    const response = await request(app.callback())
+        .get('/v3/01jthv2t5k88yermamssn96pzf/golda_meir.ics?yrem=0');
+    expect(response.status).toBe(200);
+    expect(response.type).toMatch(/calendar/);
+    expect(response.text).toContain('Golda Meir');
+    expect(response.text).not.toContain('Yahrzeit reminder');
+  });
+
+  it('omits day-before reminder events when yrem=off', async () => {
+    const response = await request(app.callback())
+        .get('/v3/01jthv2t5k88yermamssn96pzf/golda_meir.ics?yrem=off');
+    expect(response.status).toBe(200);
+    expect(response.text).not.toContain('Yahrzeit reminder');
+  });
+
+  it('omits day-before reminder events from CSV export when yrem=0', async () => {
+    const response = await request(app.callback())
+        .get('/v3/01jthv2t5k88yermamssn96pzf/golda_meir.csv?yrem=0');
+    expect(response.status).toBe(200);
+    expect(response.type).toMatch(/csv/);
+    expect(response.text).not.toContain('Yahrzeit reminder');
+  });
 });
 
 describe('Dirshu Amud HaYomi protobuf round-trip', () => {

--- a/views/partials/emoji-switch-script.ejs
+++ b/views/partials/emoji-switch-script.ejs
@@ -33,6 +33,9 @@ document.addEventListener('DOMContentLoaded', function() {
       if (!emojiChecked) {
         url.searchParams.set('emoji', '0');
       }
+      if (!yahrzeitReminderChecked) {
+        url.searchParams.set('yrem', '0');
+      }
       btn2.href = url.href;
     }
   }


### PR DESCRIPTION
The "Download personal.ics" alternative button (used by the Outlook PC
tab) rebuilt its URL from ics1year but only carried the emoji setting,
never yrem. Unchecking "Calendar reminder day before yahrzeit" therefore
had no effect on the downloaded file. Apply yrem=0 to the -alt button
when the reminder checkbox is unchecked, matching the primary button.

https://claude.ai/code/session_01BTT4dYfSruzuEAvSHLdFbw