### PR TITLE
test: mock geo lookups via Location.lookup so suite passes on minimal test DB

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "type": "module",
   "engines": {
-    "node": ">= 24"
+    "node": ">= 22.5"
   },
   "files": [],
   "scripts": {

--- a/test/download.test.js
+++ b/test/download.test.js
@@ -53,9 +53,9 @@ describe('v4 ICS downloads', () => {
 });
 
 describe('v4 CSV downloads', () => {
-  it('returns 200 CSV for /v4/.../hebcal_2026_patrick_eur.csv', async () => {
+  it('returns 200 CSV for /v4/.../hebcal_2026_berlin.csv', async () => {
     const response = await request(app.callback())
-        .get('/v4/CAEQARgBIAEoATABQAFQAViX17kBYOoPagFziAEB2AEB/hebcal_2026_patrick_eur.csv');
+        .get('/v4/CAEQARgBIAEoATABQAFQAViPiLQBYOoPagFziAEB2AEB/hebcal_2026_berlin.csv');
     expect(response.status).toBe(200);
     expect(response.type).toMatch(/csv/);
     expect(response.text).toBeTruthy();
@@ -63,16 +63,16 @@ describe('v4 CSV downloads', () => {
 });
 
 describe('v4 PDF downloads', () => {
-  it('returns 200 PDF for /v4/.../hebcal_2020_bayshore_gardens.pdf', async () => {
+  it('returns 200 PDF for /v4/.../hebcal_2020_new_york.pdf', async () => {
     const response = await request(app.callback())
-        .get('/v4/CAEYAUABWPaN_QFg5A9qAXN4EogBAQ/hebcal_2020_bayshore_gardens.pdf');
+        .get('/v4/CAEYAUABWIWDuQJg5A9qAXN4EogBAQ/hebcal_2020_new_york.pdf');
     expect(response.status).toBe(200);
     expect(response.type).toMatch(/pdf/);
   });
 
-  it('returns 200 PDF for /v4/.../hebcal_2021_alberti.pdf', async () => {
+  it('returns 200 PDF for /v4/.../hebcal_2021_toronto.pdf', async () => {
     const response = await request(app.callback())
-        .get('/v4/CAEYAUABUAFYr_7rAWDlD2oBc3gSiAEB/hebcal_2021_alberti.pdf');
+        .get('/v4/CAEYAUABWLm6-AJg5Q9qAXN4EogBAQ/hebcal_2021_toronto.pdf');
     expect(response.status).toBe(200);
     expect(response.type).toMatch(/pdf/);
   });
@@ -277,7 +277,7 @@ describe('304 Not Modified (ETag / If-None-Match)', () => {
   });
 
   it('returns 304 for CSV when If-None-Match matches ETag', async () => {
-    const csvPath = '/v4/CAEQARgBIAEoATABQAFQAViX17kBYOoPagFziAEB2AEB/hebcal_2026_patrick_eur.csv';
+    const csvPath = '/v4/CAEQARgBIAEoATABQAFQAViPiLQBYOoPagFziAEB2AEB/hebcal_2026_berlin.csv';
     const first = await request(app.callback()).get(csvPath);
     expect(first.status).toBe(200);
     const etag = first.headers['etag'];
@@ -291,7 +291,7 @@ describe('304 Not Modified (ETag / If-None-Match)', () => {
   });
 
   it('returns 304 for PDF when If-None-Match matches ETag', async () => {
-    const pdfPath = '/v4/CAEYAUABWPaN_QFg5A9qAXN4EogBAQ/hebcal_2020_bayshore_gardens.pdf';
+    const pdfPath = '/v4/CAEYAUABWIWDuQJg5A9qAXN4EogBAQ/hebcal_2020_new_york.pdf';
     const first = await request(app.callback()).get(pdfPath);
     expect(first.status).toBe(200);
     const etag = first.headers['etag'];

--- a/test/geonamesMock.js
+++ b/test/geonamesMock.js
@@ -1,0 +1,106 @@
+import {GeoDb} from '@hebcal/geo-sqlite';
+import {Location} from '@hebcal/core';
+
+// The ~60 "classic" Hebcal city names recognized by Location.lookup() in
+// @hebcal/core. The test geonames.sqlite3 only contains a tiny sample of
+// cities, so lookups for these well-known cities (and their geonameids)
+// would otherwise return null. We bridge that gap by falling back to the
+// hardcoded data baked into @hebcal/core.
+const CLASSIC_CITIES = [
+  'Ashdod', 'Atlanta', 'Austin', 'Baghdad', 'Beer Sheva',
+  'Berlin', 'Baltimore', 'Bogota', 'Boston', 'Budapest',
+  'Buenos Aires', 'Buffalo', 'Chicago', 'Cincinnati', 'Cleveland',
+  'Dallas', 'Denver', 'Detroit', 'Eilat', 'Gibraltar', 'Haifa',
+  'Hawaii', 'Helsinki', 'Houston', 'Jerusalem', 'Johannesburg',
+  'Kiev', 'La Paz', 'Livingston', 'Las Vegas', 'London', 'Los Angeles',
+  'Marseilles', 'Miami', 'Minneapolis', 'Melbourne', 'Mexico City',
+  'Montreal', 'Moscow', 'New York', 'Omaha', 'Ottawa', 'Panama City',
+  'Paris', 'Pawtucket', 'Petach Tikvah', 'Philadelphia', 'Phoenix',
+  'Pittsburgh', 'Providence', 'Portland', 'Saint Louis', 'Saint Petersburg',
+  'San Diego', 'San Francisco', 'Sao Paulo', 'Seattle', 'Sydney',
+  'Tel Aviv', 'Tiberias', 'Toronto', 'Vancouver', 'White Plains',
+  'Washington DC', 'Worcester',
+];
+
+/**
+ * Builds (and caches on the instance) a Map of geonameid => classic city name
+ * by munging each classic city name and looking up its geonameid in the
+ * GeoDb's built-in legacy city table.
+ * @param {GeoDb} db
+ * @return {Map<number, string>}
+ */
+function id2nameFor(db) {
+  if (db._testId2Name) {
+    return db._testId2Name;
+  }
+  const map = new Map();
+  for (const name of CLASSIC_CITIES) {
+    const key = GeoDb.munge(name);
+    let id = db.legacyCities.get(key);
+    if (!id) {
+      // Some classic cities are only stored under a country/state-qualified
+      // key, e.g. 'br-saopaulo' or 'us-lasvegas-nv'. Match those too.
+      const escaped = key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      const re = new RegExp(`^[a-z]{2}-${escaped}(-.+)?$`);
+      for (const [k, v] of db.legacyCities) {
+        if (re.test(k)) {
+          id = v;
+          break;
+        }
+      }
+    }
+    if (id) {
+      map.set(id, name);
+    }
+  }
+  db._testId2Name = map;
+  return map;
+}
+
+let patched = false;
+
+/**
+ * Patches GeoDb so that lookupGeoname() and lookupLegacyCity() fall back to
+ * Location.lookup() from @hebcal/core when the (intentionally minimal) test
+ * SQLite database has no row for the requested city. Idempotent.
+ */
+export function injectGeonamesMock() {
+  if (patched) {
+    return;
+  }
+  patched = true;
+
+  const origLookupGeoname = GeoDb.prototype.lookupGeoname;
+  GeoDb.prototype.lookupGeoname = function(geonameid) {
+    const loc = origLookupGeoname.call(this, geonameid);
+    if (loc) {
+      return loc;
+    }
+    let id = +geonameid;
+    if (id === 293396) {
+      id = 293397; // same alias GeoDb.lookupGeoname() applies internally
+    }
+    const name = id2nameFor(this).get(id);
+    const found = name ? Location.lookup(name) : null;
+    if (!found) {
+      return null;
+    }
+    // Location.lookup() returns a shared cached instance with no geonameid.
+    // Clone it and stamp the geoname identity, matching real lookupGeoname().
+    const clone = Object.assign(
+        Object.create(Object.getPrototypeOf(found)), found);
+    clone.geo = 'geoname';
+    clone.geonameid = id;
+    clone.geoid = id;
+    return clone;
+  };
+
+  const origLookupLegacyCity = GeoDb.prototype.lookupLegacyCity;
+  GeoDb.prototype.lookupLegacyCity = function(cityName) {
+    const loc = origLookupLegacyCity.call(this, cityName);
+    if (loc) {
+      return loc;
+    }
+    return Location.lookup(cityName) ?? null;
+  };
+}

--- a/test/hebcal.test.js
+++ b/test/hebcal.test.js
@@ -7,7 +7,7 @@ import {injectZipsMock} from './zipsMock.js';
 describe('Hebcal Routes', () => {
   it('should return 200 for /hebcal with valid params', async () => {
     const response = await request(app.callback())
-        .get('/hebcal?c=on&geo=geoname&geonameid=2654285&m=50&maj=on&mf=on&min=on&mod=on&nx=on&s=on&ss=on&v=1&year=2023');
+        .get('/hebcal?c=on&geo=geoname&geonameid=5128581&m=50&maj=on&mf=on&min=on&mod=on&nx=on&s=on&ss=on&v=1&year=2023');
     expect(response.status).toBe(200);
     expect(response.type).toContain('html');
   });

--- a/test/misc.test.js
+++ b/test/misc.test.js
@@ -46,7 +46,7 @@ describe('Zmanim and Omer Routes', () => {
 describe('Autocomplete Routes', () => {
   it('should return 200 for /complete with query', async () => {
     const response = await request(app.callback())
-        .get('/complete?q=san+francisco');
+        .get('/complete?q=Whyalla');
     expect(response.status).toBe(200);
     expect(response.type).toContain('json');
   });
@@ -59,15 +59,18 @@ describe('Autocomplete Routes', () => {
   });
 
   it('should handle /complete with international characters', async () => {
+    // Néa Alikarnassós (Greece) exercises non-ASCII / accented input.
     const response = await request(app.callback())
-        .get('/complete?q=%D7%AA%D7%9C%20%D7%90%D7%91%D7%99%D7%91');
+        .get('/complete?q=N%C3%A9a%20Alikarnass%C3%B3s');
     expect(response.status).toBe(200);
     expect(response.type).toContain('json');
   });
 
-  it('should not include admin1 in value for Berlin', async () => {
+  it('should not include admin1 in value for an Israeli city', async () => {
+    // Israeli cities carry an admin1 (district) but it is intentionally
+    // omitted from the displayed value (e.g. "Mevo Shivta, Israel").
     const response = await request(app.callback())
-        .get('/complete?q=Berlin');
+        .get('/complete?q=Mevo+Shivta');
     expect(response.status).toBe(200);
     expect(response.type).toContain('json');
     const body = response.body;
@@ -75,14 +78,14 @@ describe('Autocomplete Routes', () => {
     expect(Array.isArray(body)).toBe(true);
     expect(body.length).toBeGreaterThanOrEqual(1);
     expect(body[0]).toEqual({
-      'admin1': 'State of Berlin',
-      'asciiname': 'Berlin',
-      'cc': 'DE',
-      'country': 'Germany',
-      'flag': '🇩🇪',
+      'admin1': 'Southern District',
+      'asciiname': 'Mevo Shivta',
+      'cc': 'IL',
+      'country': 'Israel',
+      'flag': '🇮🇱',
       'geo': 'geoname',
-      'id': 2950159,
-      'value': 'Berlin, Germany',
+      'id': 294240,
+      'value': 'Mevo Shivta, Israel',
     });
   });
 });

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,0 +1,5 @@
+import {injectGeonamesMock} from './geonamesMock.js';
+
+// The test geonames.sqlite3 only contains a small sample of cities, so geo
+// lookups for well-known cities fall back to @hebcal/core's built-in data.
+injectGeonamesMock();

--- a/test/shabbat.test.js
+++ b/test/shabbat.test.js
@@ -34,14 +34,14 @@ describe('Shabbat Routes', () => {
 
   it('should return 200 for /shabbat/', async () => {
     const response = await request(app.callback())
-        .get('/shabbat/?geonameid=2451778');
+        .get('/shabbat/?geonameid=5128581');
     expect(response.status).toBe(200);
     expect(response.type).toContain('html');
   });
 
   it('should return 200 for /shabbat/browse/', async () => {
     const response = await request(app.callback())
-        .get('/shabbat/browse/italy-sicily');
+        .get('/shabbat/browse/italy-calabria');
     expect(response.status).toBe(200);
     expect(response.type).toContain('html');
   });
@@ -53,9 +53,9 @@ describe('Shabbat Routes', () => {
     expect(response.type).toContain('xml');
   });
 
-  it('should return 200 for /shabbat/browse/costa-rica.xml', async () => {
+  it('should return 200 for /shabbat/browse/australia.xml', async () => {
     const response = await request(app.callback())
-        .get('/shabbat/browse/costa-rica.xml');
+        .get('/shabbat/browse/australia.xml');
     expect(response.status).toBe(200);
     expect(response.type).toContain('xml');
   });

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     globals: false,
     environment: 'node',
+    setupFiles: ['./test/setup.js'],
     testTimeout: 10000,
     hookTimeout: 10000,
     coverage: {


### PR DESCRIPTION
The test geonames.sqlite3 produced by make-test-dbs only contains a tiny
sample of cities, so GeoDb.lookupLegacyCity('New York') and
lookupGeoname() for well-known geonameids returned null, cascading into
500/404 errors across most route tests.

- Add test/geonamesMock.js: patches GeoDb.lookupGeoname/lookupLegacyCity
  to fall back to @hebcal/core's Location.lookup() (its ~60 "classic"
  cities) when the minimal test DB has no matching row. Geoname identity
  (geonameid/geo) is stamped on the cloned Location so redirect/self URLs
  resolve correctly.
- Wire it in globally via test/setup.js (vitest setupFiles).
- Point the remaining data-dependent tests at cities/admin1/countries that
  exist in the minimal test DB or in the classic-city list (re-encoded v4
  download protobufs, swapped geonameids, browse italy-calabria/australia,
  Israeli-city autocomplete, accented international query).
- Relax engines.node to ">= 22.5" (node:sqlite/DatabaseSync is available
  from v22.5; full suite passes on both Node 22 and 24).

https://claude.ai/code/session_01Dbjy1Lp7LrKddRvmqMYGZg