### PR TITLE
Extract Israel/Diaspora disclaimer into reusable partial

### DIFF
--- a/views/holiday-main-index.ejs
+++ b/views/holiday-main-index.ejs
@@ -28,8 +28,7 @@ on the last date specified. For example, if the dates for Rosh
 Hashana are listed as <strong><time datetime="<%=RH.subtract(1, 'd').format('YYYY-MM-DD')%>"><%=RH.subtract(1, 'd').format('MMM D')%></time>-<time datetime="<%=RH.add(1, 'd').format('YYYY-MM-DD')%>"><%=RH.add(1, 'd').format('MMM D')%></time></strong>,
 then the holiday begins at sundown on <strong><%=RH.subtract(1, 'd').format('MMM D')%></strong>
 and ends at nightfall on <strong><%=RH.add(1, 'd').format('MMM D')%></strong>.</p>
-<p class="small">This page displays the <%=il?'Israel':'Diaspora'%> holiday schedule.
-The <a href="<%=inverse.href%>"><%=il?'Diaspora':'Israel'%> schedule</a> is used by Jews living <%=il?'outside of':'in'%> modern Israel.</p>
+<p class="small"><%- await include('partials/israel-diaspora-note.ejs', {il, href: inverse.href, subject: 'holiday schedule'}) -%></p>
 </div><!-- .col-sm-8 -->
 <div class="col-sm-4 d-print-none">
 <div class="d-flex justify-content-center d-print-none">

--- a/views/holidayDetail.ejs
+++ b/views/holidayDetail.ejs
@@ -82,9 +82,7 @@ href="<%=meta.wikipedia.href%>">Wikipedia</a>
 </table>
 </div><!-- #chanukah-candles -->
 <% } else if (pesachSukkotItems !== null) { %>
-<p class="small">This page displays the <%=il?'Israel':'Diaspora'%> holiday schedule.
-The <a href="<%=rpath%><%=il?'':'?i=on'%>"><%=il?'Diaspora':'Israel'%> schedule</a> is used by
-Jews living <%=il?'outside of':'in'%> modern Israel.</p>
+<p class="small"><%- await include('partials/israel-diaspora-note.ejs', {il, href: rpath + (il ? '' : '?i=on'), subject: 'holiday schedule'}) -%></p>
 <div class="table-responsive" id="shalosh-regalim">
 <table class="table table-striped">
 <colgroup><col><col></colgroup>
@@ -161,9 +159,7 @@ data-ad-slot="5342180883"></ins>
 <% if (typeof meta.reading !== 'undefined') { %>
 <h3 id="reading" class="mt-4">Tanakh</h3>
 <% if (isShaloshRegalim) { %>
-<p class="small">This page displays the <%=il?'Israel':'Diaspora'%> holiday schedule.
-The <a href="<%=rpath%><%=il?'':'?i=on'%>"><%=il?'Diaspora':'Israel'%> schedule</a> is used by
-Jews living <%=il?'outside of':'in'%> modern Israel.</p>
+<p class="small"><%- await include('partials/israel-diaspora-note.ejs', {il, href: rpath + (il ? '' : '?i=on'), subject: 'holiday schedule'}) -%></p>
 <% } %>
 <% if (Object.keys(meta.reading).length >= 3) { %>
 <div class="d-print-none">

--- a/views/parsha-detail.ejs
+++ b/views/parsha-detail.ejs
@@ -35,9 +35,7 @@ Next read <% if (israelDiasporaDiffer) { %>in <%=locationName%><% } %> on
 <% } -%>
 </p>
 <% if (israelDiasporaDiffer) { -%>
-<p><small>This page displays the <%=il?'Israel':'Diaspora'%> Torah reading for <%=parshaName%><%= date ? ' ' + hd.getFullYear() : '' %>.
-The <a href="<%=date ? otherLocationAnchor : parshaAnchor + (il?'':'?i=on')%>"><%=il?'Diaspora':'Israel'%> schedule</a> is used
-by Jews living <%=il?'outside of':'in'%> modern Israel.</small></p>
+<p><small><%- await include('partials/israel-diaspora-note.ejs', {il, href: date ? otherLocationAnchor : parshaAnchor + (il ? '' : '?i=on'), subject: 'Torah reading for ' + parshaName + (date ? ' ' + hd.getFullYear() : '')}) -%></small></p>
 <% } -%>
 <h4 id="torah"><span class="d-none d-sm-inline">Torah Portion:</span>
 <% if (reading.torahHtml) { %><%- reading.torahHtml -%>

--- a/views/parsha-multi-year-index.ejs
+++ b/views/parsha-multi-year-index.ejs
@@ -18,9 +18,7 @@
 <%- await include('partials/warning-1752.ejs') -%>
 <% } -%>
 <h2>Shabbat Torah Readings <%=hyear-1%>-<%=hyear+4%></h2>
-<p class="small">This page displays the <%=il?'Israel':'Diaspora'%> Torah reading schedule.
-The <a href="<%=inverse.href%>"><%=il?'Diaspora':'Israel'%> schedule</a> is used
-by Jews living <%=il?'outside of':'in'%> modern Israel.</p>
+<p class="small"><%- await include('partials/israel-diaspora-note.ejs', {il, href: inverse.href, subject: 'Torah reading schedule'}) -%></p>
 <div class="table-responsive">
 <table class="table table-striped">
 <colgroup>

--- a/views/parsha-year.ejs
+++ b/views/parsha-year.ejs
@@ -27,9 +27,7 @@ over the course of one Hebrew calendar year.</p>
 href="#hcdl-modal" role="button" data-bs-toggle="modal"
 data-bs-target="#hcdl-modal"><svg class="icon icon-sm"><use
 href="<%=spriteHref%>#bi-cloud-download"></use></svg> Download</a>
-<small>This page displays the <%=il?'Israel':'Diaspora'%> Torah reading schedule.
-The <a href="<%=hyear%>?i=<%=il?'off':'on'%>"><%=il?'Diaspora':'Israel'%> schedule</a> is used
-by Jews living <%=il?'outside of':'in'%> modern Israel.</small></p>
+<small><%- await include('partials/israel-diaspora-note.ejs', {il, href: hyear + '?i=' + (il ? 'off' : 'on'), subject: 'Torah reading schedule'}) -%></small></p>
 
 <table class="table table-striped">
 <colgroup>

--- a/views/partials/israel-diaspora-note.ejs
+++ b/views/partials/israel-diaspora-note.ejs
@@ -1,0 +1,8 @@
+<%# Israel/Diaspora schedule disclaimer sentence.
+   Locals:
+     il      - boolean, true when displaying the Israel schedule
+     href    - link to the inverse (other location) schedule
+     subject - noun phrase, e.g. 'holiday schedule', 'Torah reading schedule'
+   Caller is responsible for the wrapping element (e.g. <p class="small">). -%>
+This page displays the <%=il ? 'Israel' : 'Diaspora'%> <%=subject%>.
+The <a href="<%=href%>"><%=il ? 'Diaspora' : 'Israel'%> schedule</a> is used by Jews living <%=il ? 'outside of' : 'in'%> modern Israel.


### PR DESCRIPTION
## Summary
Refactored the Israel/Diaspora schedule disclaimer text that appears across multiple pages into a single reusable EJS partial component. This eliminates code duplication and makes the disclaimer easier to maintain and update consistently.

## Changes
- **Created** `views/partials/israel-diaspora-note.ejs` — new partial template that renders the Israel/Diaspora schedule disclaimer with configurable parameters:
  - `il` — boolean flag for Israel vs. Diaspora schedule
  - `href` — link to the alternate location schedule
  - `subject` — noun phrase describing what schedule is being shown (e.g., "holiday schedule", "Torah reading schedule")

- **Updated** five template files to use the new partial instead of inline disclaimer text:
  - `views/holidayDetail.ejs` — two instances (pesach/sukkot section and Tanakh reading section)
  - `views/parsha-detail.ejs` — Torah reading disclaimer
  - `views/parsha-multi-year-index.ejs` — multi-year Torah reading schedule
  - `views/parsha-year.ejs` — annual Torah reading schedule
  - `views/holiday-main-index.ejs` — main holiday index

## Implementation Details
The partial accepts the wrapping element responsibility to the caller (e.g., `<p class="small">`), allowing flexibility in how the disclaimer is styled across different pages. All instances now use consistent wording and logic through the centralized partial.

https://claude.ai/code/session_01HYVBBht3Eny7FHeTZoUaJk