### PR TITLE
Refactor Vary header filtering logic in compression middleware

### DIFF
--- a/src/app-common.js
+++ b/src/app-common.js
@@ -91,11 +91,13 @@ export function useCompression(app, {brotliQuality, zstdLevel}) {
     await next();
     const vary = ctx.response.get('Vary');
     const enc = ctx.response.get('Content-Encoding');
-    const cfg = ctx.request.query.cfg;
-    if (vary && !enc && (cfg === 'json' || cfg === 'fc')) {
-      if (vary.includes(',')) {
-        // Split headers, filter out 'Accept-Encoding', and rejoin them
-        const headers = vary.split(',').map(h => h.trim()).filter(h => h.toLowerCase() !== 'accept-encoding');
+    const type = ctx.response.type;
+    if (vary && !enc && type === 'application/json' &&
+        vary.toLowerCase().includes('accept-encoding')) {
+      // Filter out 'Accept-Encoding' and rejoin the remaining headers
+      const headers = vary.split(',').map((h) => h.trim())
+          .filter((h) => h.toLowerCase() !== 'accept-encoding');
+      if (headers.length) {
         ctx.set('Vary', headers.join(', '));
       } else {
         ctx.remove('Vary');


### PR DESCRIPTION
## Summary
Improved the Vary header filtering logic in the compression middleware to be more robust and maintainable. The change simplifies the conditional logic and makes the filtering behavior more explicit.

## Key Changes
- **Replaced query parameter check with response type check**: Changed from checking `ctx.request.query.cfg` to checking `ctx.response.type === 'application/json'` for more reliable content-type detection
- **Simplified conditional logic**: Combined multiple conditions into a single, clearer check that verifies the Vary header contains 'Accept-Encoding' before attempting to filter it
- **Improved code clarity**: Reformatted the header filtering logic with better spacing and added an explicit length check before setting the Vary header
- **Better edge case handling**: Added a check to remove the Vary header entirely if no headers remain after filtering out 'Accept-Encoding'

## Implementation Details
The refactored logic now:
1. Checks if a Vary header exists and no Content-Encoding is set
2. Verifies the response type is JSON
3. Confirms the Vary header contains 'Accept-Encoding' (case-insensitive)
4. Filters out 'Accept-Encoding' from the Vary header
5. Either updates the Vary header with remaining values or removes it if empty

This approach is more maintainable and less dependent on query parameters, making the compression middleware behavior more predictable.

https://claude.ai/code/session_01XaAUtyTgqEvnSV8tA3fRT1