### PR TITLE
Add defer to script tags that are safe to defer

### DIFF
--- a/views/api-docs.ejs
+++ b/views/api-docs.ejs
@@ -14,8 +14,8 @@
 </head>
 <body>
 <div id="swagger-ui"></div>
-<script nonce="<%=nonce%>" src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5.32.6/swagger-ui-bundle.js" crossorigin="anonymous"></script>
-<script nonce="<%=nonce%>" src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5.32.6/swagger-ui-standalone-preset.js" crossorigin="anonymous"></script>
+<script defer nonce="<%=nonce%>" src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5.32.6/swagger-ui-bundle.js" crossorigin="anonymous"></script>
+<script defer nonce="<%=nonce%>" src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5.32.6/swagger-ui-standalone-preset.js" crossorigin="anonymous"></script>
 <script nonce="<%=nonce%>">
 window.addEventListener('load', function() {
   window.ui = SwaggerUIBundle({

--- a/views/link.ejs
+++ b/views/link.ejs
@@ -104,7 +104,7 @@ href="https://www.w3.org/Style/CSS/">Cascading Style Sheets (CSS)</a> are
 very powerful and flexible.</p>
 </div><!-- .col-sm-12 -->
 </div><!-- .row -->
-<script nonce="<%=nonce%>" src="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.6.0/build/highlight.min.js"></script>
+<script defer nonce="<%=nonce%>" src="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.6.0/build/highlight.min.js"></script>
 <script nonce="<%=nonce%>">
 document.addEventListener('DOMContentLoaded', function() {
   document.querySelectorAll('pre code').forEach(function(el) {

--- a/views/partials/footer.ejs
+++ b/views/partials/footer.ejs
@@ -19,7 +19,7 @@ and <a href="https://www.maxmind.com/">MaxMind</a>, also licensed under Creative
 </div><!-- .row -->
 </footer>
 </div><!-- .container -->
-<script nonce="<%=nonce%>" src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js" integrity="sha384-FKyoEForCGlyvwx9Hj09JcYn3nv7wiPVlz7YYwJrWVcXK/BmnVDxM+D2scQbITxI" crossorigin="anonymous"></script>
+<script defer nonce="<%=nonce%>" src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js" integrity="sha384-FKyoEForCGlyvwx9Hj09JcYn3nv7wiPVlz7YYwJrWVcXK/BmnVDxM+D2scQbITxI" crossorigin="anonymous"></script>
 <% if (typeof footerScripts === 'object') { -%>
 <%   if (footerScripts.tooltip) { %><%- await include('script-tooltip.ejs') %><% } -%>
 <%   if (footerScripts.clipboard) { %><script nonce="<%=nonce%>"><%- await include('client-clipboard.min.js') %></script><% } -%>

--- a/views/partials/script-fullcalendar.ejs
+++ b/views/partials/script-fullcalendar.ejs
@@ -1,1 +1,1 @@
-<script nonce="<%=nonce%>" src="<%=holidayFcAppHref%>"></script>
+<script defer nonce="<%=nonce%>" src="<%=holidayFcAppHref%>"></script>

--- a/views/partials/script-tooltip.ejs
+++ b/views/partials/script-tooltip.ejs
@@ -1,6 +1,6 @@
 <script nonce="<%=nonce%>">
-const tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'));
-const tooltipList = tooltipTriggerList.map(function (el) {
-  return new bootstrap.Tooltip(el);
+document.addEventListener('DOMContentLoaded', function() {
+  const tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'));
+  tooltipTriggerList.forEach(function(el) { new bootstrap.Tooltip(el); });
 });
 </script>

--- a/views/partials/script-typeahead.ejs
+++ b/views/partials/script-typeahead.ejs
@@ -1,2 +1,2 @@
-<script nonce="<%=nonce%>" src="<%=clientAppHref%>"></script>
-<script nonce="<%=nonce%>">hebcalClient.createCityTypeahead(false);</script>
+<script defer nonce="<%=nonce%>" src="<%=clientAppHref%>"></script>
+<script nonce="<%=nonce%>">document.addEventListener('DOMContentLoaded', function() { hebcalClient.createCityTypeahead(false); });</script>

--- a/views/partials/script-yahrzeit-form.ejs
+++ b/views/partials/script-yahrzeit-form.ejs
@@ -152,7 +152,7 @@ mainFormEl.addEventListener('submit', function(event) {
 
 });
 </script>
-<script nonce="<%=nonce%>" src="https://cdn.jsdelivr.net/npm/papaparse@5.4.0/papaparse.min.js"></script>
+<script defer nonce="<%=nonce%>" src="https://cdn.jsdelivr.net/npm/papaparse@5.4.0/papaparse.min.js"></script>
 <script nonce="<%=nonce%>">
 document.addEventListener('DOMContentLoaded', function() {
   function processRow(row) {


### PR DESCRIPTION
FullCalendar bundle, PapaParse, highlight.js, and Swagger UI scripts all
have no synchronous inline dependents (inline code uses DOMContentLoaded
or window.load), so defer is safe and avoids blocking HTML parsing.