### PR TITLE
Fix clipboard IIFE broken by Bootstrap defer

### DIFF
--- a/src/client-clipboard.js
+++ b/src/client-clipboard.js
@@ -1,3 +1,4 @@
+document.addEventListener('DOMContentLoaded', function() {
 const grabBtnList = document.querySelectorAll('.btn.grabBtn');
 grabBtnList.forEach(function(el) {
   const tooltipBtn = new bootstrap.Tooltip(el, {
@@ -36,3 +37,4 @@ if (grabLink) {
     }, 100);
   });
 }
+});


### PR DESCRIPTION
The previous PR added `defer` to the Bootstrap bundle. This exposed a bug in `client-clipboard.js`: the IIFE called `new bootstrap.Tooltip()` synchronously, but with Bootstrap deferred it hasn't executed yet at that point.

Fix: wrap the clipboard code in a `DOMContentLoaded` listener. Deferred scripts are guaranteed to run before `DOMContentLoaded` fires, so Bootstrap will be available when the listener executes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J2FEhfRjRiNRZ5sxA6GydW)_