### PR TITLE
Remove unused hdate.bundle rollup build configuration

### DIFF
--- a/rollup.config.cjs
+++ b/rollup.config.cjs
@@ -46,22 +46,6 @@ module.exports = [
     ],
   },
   {
-    input: 'src/hdate.bundle.js',
-    output: [
-      {
-        file: 'views/partials/hdate.bundle.min.js',
-        format: 'iife',
-        name: 'hdate',
-        banner: '/*! hdate.bundle ' + pkg.version + ' */',
-      },
-    ],
-    plugins: [
-      terser(),
-      nodeResolve(),
-      stripHebcalBanner,
-    ],
-  },
-  {
     input: 'src/hdate-en.js',
     output: [
       {

--- a/src/hdate.bundle.js
+++ b/src/hdate.bundle.js
@@ -1,2 +1,0 @@
-export {greg2abs} from '@hebcal/hdate/dist/esm/greg';
-export {abs2hebrew, getMonthName} from '@hebcal/hdate/dist/esm/hdateBase';


### PR DESCRIPTION
## Summary
Removes the unused `hdate.bundle` rollup build configuration and its corresponding source file. This build target was generating a minified bundle at `views/partials/hdate.bundle.min.js` but is no longer needed.

## Changes
- Removed the `hdate.bundle` rollup configuration block from `rollup.config.cjs`
- Deleted the source file `src/hdate.bundle.js` which re-exported functions from `@hebcal/hdate`

## Notes
This appears to be cleanup of legacy build artifacts. The bundle was configured to output to `views/partials/` but is not referenced in the current codebase.

https://claude.ai/code/session_013NZb9YCarDhLasoWdWe3YG