### PR TITLE
Refactor hebcal results page initialization

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hebcal-web",
-  "version": "3.8.2",
+  "version": "3.8.3",
   "description": "Hebcal server-side Node.js for www.hebcal.com and download.hebcal.com",
   "repository": {
     "type": "git",

--- a/src/hebcalResults.js
+++ b/src/hebcalResults.js
@@ -792,7 +792,23 @@ function renderPagination(months) {
   window.hebcal.paginationRendered = true;
 }
 
+/**
+ * Reads the calendar data serialized in the
+ * `<script type="application/json" id="hebcalData">` tag and merges it into
+ * `window.hebcal`, returning the populated config object.
+ * @return {object}
+ */
+function loadData() {
+  window.hebcal = window.hebcal || {};
+  const el = document.getElementById('hebcalData');
+  if (el) {
+    Object.assign(window.hebcal, JSON.parse(el.textContent));
+  }
+  return window.hebcal;
+}
+
 const hebcalResults = {
+  loadData,
   makeMonthDivs,
   renderMonthTables,
   makeMonthHtml,

--- a/src/hebcalResults.js
+++ b/src/hebcalResults.js
@@ -780,7 +780,7 @@ function renderPagination(months) {
         title = localeData.months[mm - 1] + ' ' + yearStr;
         innerHTML = localeData.monthsShort[mm - 1];
       }
-      const newNode = hebcalResults.paginationListItem({
+      const newNode = paginationListItem({
         href: '#cal-' + yearMonth,
         title: title,
         innerHTML: innerHTML,
@@ -861,16 +861,8 @@ function renderResultsPage() {
 }
 
 const hebcalResults = {
-  loadData,
   renderResultsPage,
-  makeMonthDivs,
-  renderMonthTables,
-  makeMonthHtml,
-  renderCalendarGrids,
-  paginationListItem,
-  splitByMonth,
   myPrint,
-  renderPagination,
 };
 
 export default hebcalResults;

--- a/src/hebcalResults.js
+++ b/src/hebcalResults.js
@@ -807,8 +807,62 @@ function loadData() {
   return window.hebcal;
 }
 
+/**
+ * `DOMContentLoaded` handler for the hebcal results page: loads the serialized
+ * data, renders the calendar/list views, and wires up the view toggles.
+ */
+function renderResultsPage() {
+  const conf = loadData();
+  const d = document;
+  function show(el) {
+    if (el) {
+      el.style.display = 'block';
+    }
+  }
+  function hide(el) {
+    if (el) {
+      el.style.display = 'none';
+    }
+  }
+
+  const months = splitByMonth(conf.events);
+  renderPagination(months);
+  makeMonthDivs(months);
+
+  const toggleMonth = d.getElementById('toggle-month');
+  toggleMonth.onchange = function() {
+    d.querySelectorAll('div.agenda').forEach(hide);
+    renderCalendarGrids(months);
+    d.querySelectorAll('div.cal').forEach(show);
+  };
+  const toggleList = d.getElementById('toggle-list');
+  toggleList.onchange = function() {
+    d.querySelectorAll('div.cal').forEach(hide);
+    renderMonthTables(months);
+    d.querySelectorAll('div.agenda').forEach(show);
+  };
+  if (window.innerWidth >= 768) {
+    renderCalendarGrids(months);
+    toggleMonth.checked = true;
+    toggleList.checked = false;
+  } else {
+    renderMonthTables(months);
+    toggleList.checked = true;
+    toggleMonth.checked = false;
+  }
+  const loadingEl = d.getElementById('hebcal-loading');
+  loadingEl.style.display = 'none';
+  const offcanvasEl = d.getElementById('offcanvas-settings');
+  offcanvasEl.addEventListener('show.bs.offcanvas', function() {
+    const _paq = window._paq = window._paq || [];
+    _paq.push(['trackEvent', 'Interaction', 'settings',
+      conf.shortTitle + ' ' + conf.locationName]);
+  });
+}
+
 const hebcalResults = {
   loadData,
+  renderResultsPage,
   makeMonthDivs,
   renderMonthTables,
   makeMonthHtml,

--- a/views/hebcal-results.ejs
+++ b/views/hebcal-results.ejs
@@ -174,47 +174,9 @@ data-ad-slot="1867606375"></ins>
 <%- await include('partials/emoji-switch-script.ejs') -%>
 <script nonce="<%=nonce%>"><%- await include('partials/hebcalResults.min.js') %></script>
 <%- await include('partials/print-iframe.ejs') -%>
-<script type="application/json" id="hebcalData"><%- JSON.stringify({lang: q.lg || "s", locale: locale, cconfig: cconfig, localeConfig: localeConfig, events: items, memos: memos, opts: opts}) %></script>
+<script type="application/json" id="hebcalData"><%- JSON.stringify({lang: q.lg || "s", locale: locale, cconfig: cconfig, localeConfig: localeConfig, events: items, memos: memos, opts: opts, shortTitle: shortTitle, locationName: locationName}) %></script>
 <script nonce="<%=nonce%>">
-document.addEventListener('DOMContentLoaded', function() {
-  hebcalResults.loadData();
-  const d = document;
-  function show(el) { if (el) { el.style.display = 'block' } }
-  function hide(el) { if (el) { el.style.display = 'none' } }
-
-  const months = hebcalResults.splitByMonth(window.hebcal.events);
-  hebcalResults.renderPagination(months);
-  hebcalResults.makeMonthDivs(months);
-
-  const toggleMonth = d.getElementById('toggle-month');
-  toggleMonth.onchange = function() {
-    d.querySelectorAll('div.agenda').forEach(hide);
-    hebcalResults.renderCalendarGrids(months);
-    d.querySelectorAll('div.cal').forEach(show);
-  };
-  const toggleList = d.getElementById('toggle-list');
-  toggleList.onchange = function() {
-    d.querySelectorAll('div.cal').forEach(hide);
-    hebcalResults.renderMonthTables(months);
-    d.querySelectorAll('div.agenda').forEach(show);
-  };
-  if (window.innerWidth >= 768) {
-    hebcalResults.renderCalendarGrids(months);
-    toggleMonth.checked = true;
-    toggleList.checked = false;
-  } else {
-    hebcalResults.renderMonthTables(months);
-    toggleList.checked = true;
-    toggleMonth.checked = false;
-  }
-  const loadingEl = d.getElementById('hebcal-loading');
-  loadingEl.style.display = 'none';
-  const offcanvasEl = document.getElementById('offcanvas-settings');
-  offcanvasEl.addEventListener('show.bs.offcanvas', function () {
-    var _paq = window._paq = window._paq || [];
-    _paq.push(['trackEvent', 'Interaction', 'settings', '<%=shortTitle+" "+locationName%>']);
-  });
-});
+document.addEventListener('DOMContentLoaded', hebcalResults.renderResultsPage);
 </script>
 <% const typeaheadScript = await include('partials/script-typeahead.ejs'); -%>
 <% const hebcalFormScript = await include('partials/script-hebcal-form.ejs'); -%>

--- a/views/hebcal-results.ejs
+++ b/views/hebcal-results.ejs
@@ -174,16 +174,10 @@ data-ad-slot="1867606375"></ins>
 <%- await include('partials/emoji-switch-script.ejs') -%>
 <script nonce="<%=nonce%>"><%- await include('partials/hebcalResults.min.js') %></script>
 <%- await include('partials/print-iframe.ejs') -%>
+<script type="application/json" id="hebcalData"><%- JSON.stringify({lang: q.lg || "s", locale: locale, cconfig: cconfig, localeConfig: localeConfig, events: items, memos: memos, opts: opts}) %></script>
 <script nonce="<%=nonce%>">
 document.addEventListener('DOMContentLoaded', function() {
-  window.hebcal=window.hebcal||{};
-  window.hebcal.lang='<%= q.lg || "s" %>';
-  window.hebcal.locale='<%= locale %>';
-  window.hebcal.cconfig=<%- JSON.stringify(cconfig) %>;
-  window.hebcal.localeConfig=<%- JSON.stringify(localeConfig) %>;
-  window.hebcal.events=<%- JSON.stringify(items) %>;
-  window.hebcal.memos=<%- JSON.stringify(memos) %>;
-  window.hebcal.opts=<%- JSON.stringify(opts) %>;
+  hebcalResults.loadData();
   const d = document;
   function show(el) { if (el) { el.style.display = 'block' } }
   function hide(el) { if (el) { el.style.display = 'none' } }

--- a/views/hebcal-results.ejs
+++ b/views/hebcal-results.ejs
@@ -174,7 +174,17 @@ data-ad-slot="1867606375"></ins>
 <%- await include('partials/emoji-switch-script.ejs') -%>
 <script nonce="<%=nonce%>"><%- await include('partials/hebcalResults.min.js') %></script>
 <%- await include('partials/print-iframe.ejs') -%>
-<script type="application/json" id="hebcalData"><%- JSON.stringify({lang: q.lg || "s", locale: locale, cconfig: cconfig, localeConfig: localeConfig, events: items, memos: memos, opts: opts, shortTitle: shortTitle, locationName: locationName}) %></script>
+<script type="application/json" id="hebcalData"><%- JSON.stringify({
+  lang: q.lg || "s",
+  locale,
+  cconfig,
+  localeConfig,
+  events: items,
+  memos,
+  opts,
+  shortTitle,
+  locationName,
+}) %></script>
 <script nonce="<%=nonce%>">
 document.addEventListener('DOMContentLoaded', hebcalResults.renderResultsPage);
 </script>

--- a/views/hebcal-results.ejs
+++ b/views/hebcal-results.ejs
@@ -157,6 +157,23 @@ data-ad-slot="1867606375"></ins>
 </div><!-- #hebcal-loading -->
 <div id="hebcal-results">
 </div><!-- #hebcal-results -->
+<script type="application/json" id="hebcalData">
+<%- JSON.stringify({
+  lang: q.lg || "s",
+  locale,
+  cconfig,
+  localeConfig,
+  events: items,
+  memos,
+  opts,
+  shortTitle,
+  locationName,
+}) %>
+</script>
+<script nonce="<%=nonce%>">
+<%- await include('partials/hebcalResults.min.js') -%>
+document.addEventListener('DOMContentLoaded', hebcalResults.renderResultsPage);
+</script>
 <%- await include('partials/pagination.ejs') -%>
 <div class="offcanvas offcanvas-start" style="width:auto" tabindex="-1" id="offcanvas-settings" aria-labelledby="settings-label" role="dialog" aria-modal="true">
 <div class="offcanvas-header">
@@ -172,22 +189,7 @@ data-ad-slot="1867606375"></ins>
 <% if (q.c === 'on') { %><%- await include('partials/email-candles-modal.ejs') _%><% } %>
 <% } -%>
 <%- await include('partials/emoji-switch-script.ejs') -%>
-<script nonce="<%=nonce%>"><%- await include('partials/hebcalResults.min.js') %></script>
 <%- await include('partials/print-iframe.ejs') -%>
-<script type="application/json" id="hebcalData"><%- JSON.stringify({
-  lang: q.lg || "s",
-  locale,
-  cconfig,
-  localeConfig,
-  events: items,
-  memos,
-  opts,
-  shortTitle,
-  locationName,
-}) %></script>
-<script nonce="<%=nonce%>">
-document.addEventListener('DOMContentLoaded', hebcalResults.renderResultsPage);
-</script>
 <% const typeaheadScript = await include('partials/script-typeahead.ejs'); -%>
 <% const hebcalFormScript = await include('partials/script-hebcal-form.ejs'); -%>
 <%- await include('partials/footer.ejs', {


### PR DESCRIPTION
## Summary
Refactored the hebcal results page initialization to move data loading and DOM setup logic from inline EJS template script into dedicated JavaScript functions, improving code organization and maintainability.

## Key Changes
- **Extracted `loadData()` function**: Reads serialized calendar data from a `<script type="application/json" id="hebcalData">` tag and merges it into `window.hebcal`
- **Extracted `renderResultsPage()` function**: Consolidated the entire `DOMContentLoaded` handler logic (data loading, pagination, calendar/list rendering, view toggle setup) into a single reusable function
- **Simplified module exports**: Reduced `hebcalResults` export to only expose `renderResultsPage` and `myPrint`, removing intermediate functions that are now internal
- **Fixed function reference**: Changed `hebcalResults.paginationListItem()` to direct `paginationListItem()` call in `renderPagination()`
- **Updated EJS template**: Moved inline initialization script to use the new `renderResultsPage()` function; serialized config data now lives in a JSON script tag for cleaner separation of concerns
- **Version bump**: Updated package.json to 3.8.3

## Implementation Details
The refactoring maintains identical functionality while improving code structure:
- Data serialization happens server-side in the EJS template (JSON script tag)
- Client-side JavaScript is now purely functional with no inline initialization
- The `DOMContentLoaded` event listener is wired up declaratively in the template
- All helper functions (`splitByMonth`, `renderPagination`, `makeMonthDivs`, etc.) remain internal to the module

https://claude.ai/code/session_01ERKYKkMs38XRMmXkaNQDt3