### PR TITLE
Replace koa-prometheus-exporter with prom-client

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "vitest": "^4.1.9"
   },
   "dependencies": {
-    "@echo-health/koa-prometheus-exporter": "^1.0.4",
     "@hebcal/core": "^6.6.0",
     "@hebcal/geo-sqlite": "^5.11.0",
     "@hebcal/hdate": "^0.22.4",
@@ -106,6 +105,7 @@
     "pdfkit": "^0.19.1",
     "pino": "^10.3.1",
     "probe-image-size": "^7.3.0",
+    "prom-client": "^15.1.3",
     "quick-lru": "^7.3.0",
     "random-bigint": "0.0.1",
     "simpledotcss": "^2.3.7",

--- a/src/app-common.js
+++ b/src/app-common.js
@@ -9,7 +9,13 @@ import zlib from 'node:zlib';
 import {join} from 'node:path';
 import {makeLogger, errorLogger, accessLogger, makeLogInfo} from './logger.js';
 import {MysqlDb} from './db.js';
-import prometheus from '@echo-health/koa-prometheus-exporter';
+import promClient from 'prom-client';
+
+// Collect Node.js default metrics (event-loop lag percentiles, the
+// nodejs_gc_duration_seconds histogram, heap usage, etc.) into the default
+// registry. Done once at module load: this module is cached, and in production
+// www and download run as separate processes so each gets its own collector.
+promClient.collectDefaultMetrics();
 
 /**
  * Directory for log files (and the koa.pid file) in production.
@@ -49,7 +55,6 @@ export function useObservability(app) {
   app.use(accessLogger(logger));
   app.on('error', errorLogger(logger));
 
-  const promClient = prometheus.client;
   const httpRequestsTotal = new promClient.Counter({
     name: 'http_requests_total',
     help: 'Total number of HTTP requests',
@@ -61,7 +66,14 @@ export function useObservability(app) {
         .labels(ctx.request.method, ctx.response.status)
         .inc();
   });
-  app.use(prometheus.middleware({}));
+  app.use(async function metricsEndpoint(ctx, next) {
+    if (ctx.path === '/metrics' && ctx.method === 'GET') {
+      ctx.set('Content-Type', promClient.register.contentType);
+      ctx.body = await promClient.register.metrics();
+      return;
+    }
+    await next();
+  });
 }
 
 /**


### PR DESCRIPTION
## Summary
Replaces the `@echo-health/koa-prometheus-exporter` dependency with the standard `prom-client` library, implementing a custom metrics endpoint middleware instead of relying on the wrapper package.

## Changes
- **Dependency update**: Removed `@echo-health/koa-prometheus-exporter`, added `prom-client` (^15.1.3)
- **Metrics initialization**: Added `promClient.collectDefaultMetrics()` at module load to collect Node.js runtime metrics (event-loop lag, GC duration, heap usage, etc.)
- **Custom middleware**: Replaced `prometheus.middleware({})` with a custom `metricsEndpoint` middleware that:
  - Checks for GET requests to `/metrics`
  - Sets the appropriate `Content-Type` header from the prom-client registry
  - Returns metrics via `promClient.register.metrics()`
  - Delegates other requests to the next middleware
- **Direct client usage**: Removed the intermediate `const promClient = prometheus.client` assignment and now use `prom-client` directly

## Implementation Details
The custom middleware approach provides more explicit control over the metrics endpoint while maintaining the same functionality. The `collectDefaultMetrics()` call is placed at module load in `app-common.js` (which is cached) so that in production, where www and download run as separate processes, each process gets its own collector instance.

https://claude.ai/code/session_015kkNPwFkKLCTmbRYerVwSy