### PR TITLE
getLocationFromGeoIp: return {geo: 'none'} for robot user-agents

### DIFF
--- a/src/location.js
+++ b/src/location.js
@@ -5,6 +5,7 @@ import {empty} from './empty.js';
 import {geoposLegacy} from './urlArgs.js';
 import {GeoDb} from '@hebcal/geo-sqlite';
 import {getIpAddress} from './getIpAddress.js';
+import {isRobot} from './isRobot.js';
 import {nearestCity} from './nearestCity.js';
 import {xmlEsc} from './sanitize.js';
 
@@ -16,6 +17,9 @@ import {xmlEsc} from './sanitize.js';
  */
 export function getLocationFromGeoIp(ctx, maxAccuracyRadius = 500) {
   if (!ctx.geoipCity) {
+    return {geo: 'none'};
+  }
+  if (isRobot(ctx.get('user-agent'))) {
     return {geo: 'none'};
   }
   const ip = getIpAddress(ctx);

--- a/test/location.test.js
+++ b/test/location.test.js
@@ -1,0 +1,37 @@
+import {expect, test} from 'vitest';
+import {getLocationFromGeoIp} from '../src/location.js';
+
+/**
+ * Minimal Koa-like ctx with a `get(header)` accessor and a geoipCity lookup.
+ * @param {string} userAgent
+ * @param {any} geoipResult
+ * @return {any}
+ */
+function makeCtx(userAgent, geoipResult) {
+  const headers = {'user-agent': userAgent};
+  return {
+    geoipCity: {get: () => geoipResult},
+    get(name) {
+      return headers[name.toLowerCase()] || '';
+    },
+    request: {ip: '127.0.0.1'},
+  };
+}
+
+test('getLocationFromGeoIp returns none for robot user-agent', () => {
+  const ctx = makeCtx('curl', {country: {iso_code: 'US'}});
+  expect(getLocationFromGeoIp(ctx)).toEqual({geo: 'none'});
+});
+
+test('getLocationFromGeoIp returns none for bot-like user-agent', () => {
+  const ctx = makeCtx('Mozilla/5.0 (compatible; Googlebot/2.1)', {country: {iso_code: 'US'}});
+  expect(getLocationFromGeoIp(ctx)).toEqual({geo: 'none'});
+});
+
+test('getLocationFromGeoIp does not short-circuit for human user-agent', () => {
+  const ua = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36';
+  const ctx = makeCtx(ua, null);
+  // geoip lookup returns null -> {geo: 'none'}, but this exercises the
+  // non-robot path (does not throw, falls through past the isRobot check).
+  expect(getLocationFromGeoIp(ctx)).toEqual({geo: 'none'});
+});


### PR DESCRIPTION
Short-circuit the geoIP lookup when the request comes from a known
robot/bot user-agent (via isRobot), avoiding geolocation work for
crawlers and automated clients.

Adds unit tests covering robot, bot-like, and human user-agents.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012mpjYztdfAcZjCcJjpXbcm