### PR TITLE
Delegate GeoIP lookups to hebcal-geoip2 microservice

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,13 +78,26 @@ Gettext `.po` files in `po/` (Hebrew, Portuguese, Spanish, French, Dutch, Ashken
 ### Databases
 - **MySQL**: user accounts, yahrzeit subscriptions, email lists — requires `hebcal-dot-com.ini` config
 - **SQLite** (`geonames.sqlite3`, `zips.sqlite3`): geolocation lookup via `@hebcal/geo-sqlite`
-- **MaxMind GeoIP**: `GeoLite2-Country.mmdb`, `GeoLite2-City.mmdb` for IP-based city detection
+- **MaxMind GeoIP**: IP-based city detection (`GeoLite2-City.mmdb`). The database
+  is **not** loaded in-process; lookups go to the standalone
+  [hebcal-geoip2](https://github.com/hebcal/hebcal-geoip2) Go microservice over a
+  Unix domain socket (see `src/geoipClient.js` / `src/geoip.js`). If the service
+  is unreachable, `getLocationFromGeoIp()` falls back to `{geo:'none'}`.
 
 ## Testing Notes
 
 Before first test run, create test SQLite databases:
 ```bash
 node_modules/@hebcal/geo-sqlite/bin/make-test-dbs
+```
+
+You must also run the **full** build before the tests will pass — not just
+`po2json`. Many tests boot the Koa app and render EJS templates, which require
+the compiled translations (`src/*.po.js`), the SASS/CSS output, and the rollup
+client bundles (`views/partials/*.min.js`, `static/i/*`). Without these, route
+tests fail with HTTP 500s that look unrelated to your change:
+```bash
+npm run build   # po2json + css-compile + css-rename + rollup
 ```
 
 Tests use Vitest + Supertest. Mock helpers: `test/mock-mysql.js`, `test/zipsMock.js`. All tests must pass before committing or pushing.

--- a/package.json
+++ b/package.json
@@ -96,7 +96,6 @@
     "koa-error": "^3.2.0",
     "koa-static": "^5.0.0",
     "koa-timeout-v2": "^1.0.0",
-    "maxmind": "^5.0.6",
     "minimist": "^1.2.8",
     "murmurhash3": "^0.5.0",
     "mysql2": "^3.22.5",

--- a/src/app-www.js
+++ b/src/app-www.js
@@ -3,7 +3,7 @@ import bodyParser from 'koa-bodyparser';
 import error from 'koa-error';
 import render from '@koa/ejs';
 import serve from 'koa-static';
-import {openGeoIpDbs} from './geoip.js';
+import {setupGeoIp} from './geoip.js';
 import path from 'node:path';
 import {fileURLToPath} from 'node:url';
 import os from 'node:os';
@@ -20,7 +20,7 @@ const __dirname = path.dirname(__filename);
 
 const app = createBaseApp();
 
-openGeoIpDbs(app);
+setupGeoIp(app);
 
 useObservability(app);
 

--- a/src/converter.js
+++ b/src/converter.js
@@ -33,7 +33,7 @@ const RANGE_REQUIRES_CFG_JSON = 'Date range conversion using \'start\' and \'end
 export async function hebrewDateConverter(ctx) {
   const now = ctx.state.now = new Date();
   if (ctx.method === 'GET' && ctx.request.querystring.length === 0) {
-    setDefautLangTz(ctx);
+    await setDefautLangTz(ctx);
   }
   const q = ctx.request.query;
   ctx.state.lg = q.lg || 's';

--- a/src/defaultLangTz.js
+++ b/src/defaultLangTz.js
@@ -5,15 +5,15 @@ import {processCookieAndQuery} from './urlArgs.js';
 
 /**
  * MaxMind geoIP lookup GeoLite2-City.mmdb
- * @return {any}
+ * @return {Promise<any>}
  * @param {import('koa').Context} ctx
  */
-export function setDefautLangTz(ctx) {
+export async function setDefautLangTz(ctx) {
   ctx.set('Cache-Control', 'private'); // personalize by cookie or GeoIP
   const prevCookie = ctx.cookies.get('C');
   const q = processCookieAndQuery(prevCookie, {}, ctx.request.query);
   cleanQuery(q);
-  const location = getLocationFromQueryOrGeoIp(ctx, q);
+  const location = await getLocationFromQueryOrGeoIp(ctx, q);
   const geoip = ctx.state.geoip;
   let cc = geoip?.cc;
   let tzid = geoip?.tzid;

--- a/src/fridge.js
+++ b/src/fridge.js
@@ -19,7 +19,7 @@ const CACHE_CONTROL_3DAYS = cacheControl(3);
 
 export async function fridgeShabbat(ctx) {
   if (ctx.request.path.startsWith('/fridge')) {
-    return fridgeIndex(ctx);
+    return await fridgeIndex(ctx);
   }
   const q = ctx.request.query;
   if (empty(q.year)) {
@@ -62,8 +62,8 @@ export async function fridgeShabbat(ctx) {
   return ctx.render('fridge', p);
 }
 
-function fridgeIndex(ctx) {
-  const q = setDefautLangTz(ctx);
+async function fridgeIndex(ctx) {
+  const q = await setDefautLangTz(ctx);
   const location = ctx.state.location;
   q['city-typeahead'] = location && location.geo !== 'pos' ? location.getName() : '';
   return ctx.render('fridge-index', {

--- a/src/geoip.js
+++ b/src/geoip.js
@@ -1,26 +1,34 @@
-import maxmind from 'maxmind';
+import {makeGeoipClient} from './geoipClient.js';
 
-const openOpts = {
-  watchForUpdates: true,
-  watchForUpdatesNonPersistent: false,
-};
-
-export function openGeoIpDbs(app) {
+/**
+ * Configures the GeoIP client used by getLocationFromGeoIp().
+ *
+ * Historically we opened GeoLite2-City.mmdb in-process via the `maxmind`
+ * package, which held the entire ~63 MB database in the heap for the life of
+ * the process even though fewer than ~1 in 500 requests need a GeoIP lookup.
+ * We now delegate the lookup to the standalone hebcal-geoip2 microservice
+ * (which mmaps the database, so its resident memory is a few MB) and talk to
+ * it over a Unix domain socket. See src/geoipClient.js.
+ *
+ * Config (hebcal-dot-com.ini):
+ *   hebcal.geoip.socket   path to the unix socket
+ *                         (default /run/hebcal-geoip2/geoip2.sock)
+ *   hebcal.geoip.host     optional TCP host instead of a socket (e.g. for a
+ *                         service running on another host in the VPC)
+ *   hebcal.geoip.port     optional TCP port (default 8090) when host is set
+ *
+ * @param {import('koa').Application} app
+ */
+export function setupGeoIp(app) {
   const logger = app.context.logger;
   const iniConfig = app.context.iniConfig;
-  // On Linux the GeoIP databases are installed in /var/lib/GeoIP
-  // but on macOS, they are installed by Homebrew in /opt/homebrew/var/GeoIP
-  // Allow the location to be overridden by the ini file
-  const geoipDir = iniConfig['hebcal.geoip.dir'] || '/var/lib/GeoIP';
-  // The City database is a superset of the Country database (it includes
-  // country.iso_code), so we only load the City database to reduce memory.
-  setImmediate(async () => {
-    const geoipCityMmdbPath = `${geoipDir}/GeoLite2-City.mmdb`;
-    logger.info(`Opening ${geoipCityMmdbPath}`);
-    try {
-      app.context.geoipCity = await maxmind.open(geoipCityMmdbPath, openOpts);
-    } catch (err) {
-      logger.error(err, `while opening ${geoipCityMmdbPath}`);
-    }
-  });
+  const socketPath = iniConfig['hebcal.geoip.socket'] || '/run/hebcal-geoip2/geoip2.sock';
+  const host = iniConfig['hebcal.geoip.host'];
+  const port = iniConfig['hebcal.geoip.port'];
+  app.context.geoipClient = makeGeoipClient({socketPath, host, port, logger});
+  if (host) {
+    logger.info(`GeoIP lookups via hebcal-geoip2 at ${host}:${port || 8090}`);
+  } else {
+    logger.info(`GeoIP lookups via hebcal-geoip2 at ${socketPath}`);
+  }
 }

--- a/src/geoipClient.js
+++ b/src/geoipClient.js
@@ -1,0 +1,134 @@
+import http from 'node:http';
+
+/**
+ * Client for the hebcal-geoip2 microservice (https://github.com/hebcal/hebcal-geoip2).
+ *
+ * The service memory-maps GeoLite2-City.mmdb and answers
+ * `GET /lookup?ip=<addr>` with the same subset of the MaxMind City record that
+ * the in-process `maxmind` library used to return. We keep this out of the
+ * Node.js process so we don't hold the ~63 MB database in the heap; the
+ * trade-off is a ~0.2-0.5 ms loopback round-trip on the few routes that need
+ * GeoIP (homepage, bare /shabbat, etc.).
+ *
+ * By default we talk to the service over a Unix domain socket. If the service
+ * is slow to accept a connection (or down), we fail fast and the caller falls
+ * back to {geo:'none'}.
+ */
+
+/**
+ * @typedef {Object} GeoipClientOptions
+ * @property {string} [socketPath] Unix domain socket path (default
+ *   /run/hebcal-geoip2/geoip2.sock). Ignored when host is set.
+ * @property {string} [host] TCP host (use instead of a socket, e.g. a service
+ *   on another host in the same VPC).
+ * @property {number} [port] TCP port (default 8090) when host is set.
+ * @property {number} [connectTimeout] ms to wait for the connection to be
+ *   established before giving up (default 20).
+ * @property {number} [requestTimeout] ms overall guard once connected, in case
+ *   the service accepts but stalls (default 250).
+ * @property {any} [logger] optional pino-style logger for debug diagnostics.
+ */
+
+/**
+ * @param {GeoipClientOptions} [opts]
+ * @return {{lookup: (ip: string) => Promise<any>, agent: http.Agent}}
+ */
+export function makeGeoipClient(opts = {}) {
+  const {
+    socketPath = '/run/hebcal-geoip2/geoip2.sock',
+    host,
+    port = 8090,
+    connectTimeout = 20,
+    requestTimeout = 250,
+    logger,
+  } = opts;
+  const useTcp = typeof host === 'string' && host.length > 0;
+  const agent = new http.Agent({keepAlive: true, maxSockets: 64, maxFreeSockets: 16});
+
+  /**
+   * Look up an IP address. Resolves to the MaxMind record subset, or null when
+   * the address is unknown, the input is empty, or the service is unreachable /
+   * too slow. Never rejects: GeoIP is best-effort.
+   * @param {string} ip
+   * @return {Promise<any>}
+   */
+  function lookup(ip) {
+    return new Promise((resolve) => {
+      if (!ip) {
+        resolve(null);
+        return;
+      }
+      const reqOpts = {
+        agent,
+        method: 'GET',
+        path: `/lookup?ip=${encodeURIComponent(ip)}`,
+        headers: {host: 'geoip', connection: 'keep-alive'},
+        timeout: requestTimeout,
+      };
+      if (useTcp) {
+        reqOpts.host = host;
+        reqOpts.port = port;
+      } else {
+        reqOpts.socketPath = socketPath;
+      }
+
+      let settled = false;
+      const finish = (val) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        clearTimeout(connectTimer);
+        resolve(val);
+      };
+
+      const req = http.request(reqOpts, (res) => {
+        if (res.statusCode !== 200) {
+          // 204 (not found), 4xx, 5xx -> treat as no result
+          res.resume();
+          finish(null);
+          return;
+        }
+        const chunks = [];
+        res.on('data', (c) => chunks.push(c));
+        res.on('end', () => {
+          try {
+            finish(JSON.parse(Buffer.concat(chunks).toString('utf8')));
+          } catch (err) {
+            logger?.debug?.({err}, 'geoip: bad JSON from service');
+            finish(null);
+          }
+        });
+        res.on('error', () => finish(null));
+      });
+
+      // Connect timeout: arm a short timer, cleared once the socket is
+      // actually connected. A reused keep-alive socket is already connected.
+      const connectTimer = setTimeout(() => {
+        logger?.debug?.('geoip: connect timeout');
+        req.destroy(new Error('geoip connect timeout'));
+        finish(null);
+      }, connectTimeout);
+
+      req.on('socket', (socket) => {
+        if (socket.connecting) {
+          socket.once('connect', () => clearTimeout(connectTimer));
+        } else {
+          clearTimeout(connectTimer);
+        }
+      });
+      req.on('timeout', () => {
+        req.destroy(new Error('geoip request timeout'));
+        finish(null);
+      });
+      req.on('error', (err) => {
+        // ECONNREFUSED, ENOENT (socket missing), aborts, etc.
+        logger?.debug?.({err}, 'geoip: request error');
+        finish(null);
+      });
+      req.end();
+    });
+  }
+
+  return {lookup, agent};
+}

--- a/src/homepage.js
+++ b/src/homepage.js
@@ -20,7 +20,7 @@ dayjs.extend(utc);
 dayjs.extend(timezone);
 
 export async function homepage(ctx) {
-  const q0 = setDefautLangTz(ctx);
+  const q0 = await setDefautLangTz(ctx);
   const cookie = ctx.cookies.get('C');
   const il = ctx.state.il;
   const defaults = {

--- a/src/location.js
+++ b/src/location.js
@@ -10,18 +10,20 @@ import {nearestCity} from './nearestCity.js';
 import {xmlEsc} from './sanitize.js';
 
 /**
- * MaxMind geoIP lookup GeoLite2-City.mmdb
- * @return {any}
+ * MaxMind geoIP lookup GeoLite2-City.mmdb, via the hebcal-geoip2 microservice.
+ * Returns {geo:'none'} if the lookup yields nothing or the service is
+ * unreachable (see src/geoipClient.js).
+ * @return {Promise<any>}
  * @param {import('koa').Context} ctx
  * @param {number} maxAccuracyRadius
  */
-export function getLocationFromGeoIp(ctx, maxAccuracyRadius = 500) {
+export async function getLocationFromGeoIp(ctx, maxAccuracyRadius = 500) {
   const userAgent = ctx.get('user-agent');
-  if (!userAgent || isRobot(userAgent) || !ctx.geoipCity) {
+  if (!userAgent || isRobot(userAgent) || !ctx.geoipClient) {
     return {geo: 'none'};
   }
   const ip = getIpAddress(ctx);
-  const geoip = ctx.geoipCity.get(ip);
+  const geoip = await ctx.geoipClient.lookup(ip);
   if (!geoip) {
     return {geo: 'none'};
   }
@@ -270,15 +272,15 @@ export function getLocationFromQuery(db, query) {
 /**
  * @param {import('koa').Context} ctx
  * @param {any} q
- * @return {any}
+ * @return {Promise<any>}
  */
-export function getLocationFromQueryOrGeoIp(ctx, q) {
+export async function getLocationFromQueryOrGeoIp(ctx, q) {
   const location = getLocationFromQuery(ctx.db, q);
   if (location !== null) {
     return location;
   }
   // try to infer location from GeoIP
-  const gloc = ctx.state.geoip = getLocationFromGeoIp(ctx, 1000);
+  const gloc = ctx.state.geoip = await getLocationFromGeoIp(ctx, 1000);
   if (gloc.zip || gloc.geonameid) {
     const geoip = {};
     for (const [key, val] of Object.entries(gloc)) {

--- a/src/parshaIndex.js
+++ b/src/parshaIndex.js
@@ -22,7 +22,7 @@ delete myLangNames.a;
 delete myLangNames['he-x-NoNikud'];
 
 export async function parshaIndex(ctx) {
-  const q = setDefautLangTz(ctx);
+  const q = await setDefautLangTz(ctx);
   const {dt, afterSunset} = getSunsetAwareDate(q, ctx.state.location);
   const hd0 = new HDate(dt);
   const hd = afterSunset ? hd0.next() : hd0;

--- a/src/shabbat.js
+++ b/src/shabbat.js
@@ -36,7 +36,7 @@ dayjs.extend(timezone);
 const BASE_URL = 'https://www.hebcal.com/shabbat';
 
 export async function shabbatApp(ctx) {
-  const isRedir = geoIpRedirect(ctx);
+  const isRedir = await geoIpRedirect(ctx);
   if (isRedir) {
     return;
   }
@@ -112,7 +112,7 @@ export async function shabbatApp(ctx) {
   }
 }
 
-function geoIpRedirect(ctx) {
+async function geoIpRedirect(ctx) {
   if (ctx.request.querystring.length !== 0) {
     return false;
   }
@@ -127,7 +127,7 @@ function geoIpRedirect(ctx) {
     }
   }
 
-  const geoip = ctx.state.geoip = getLocationFromGeoIp(ctx);
+  const geoip = ctx.state.geoip = await getLocationFromGeoIp(ctx);
   if (geoip.zip) {
     const dest = `/shabbat?zip=${geoip.zip}&ue=off&b=18&M=on&td=8.5&lg=s&geoip=zip`;
     redir(ctx, dest);

--- a/test/geoipClient.test.js
+++ b/test/geoipClient.test.js
@@ -1,0 +1,68 @@
+import {afterAll, beforeAll, expect, test} from 'vitest';
+import http from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+import {mkdtemp, rm} from 'node:fs/promises';
+import {makeGeoipClient} from '../src/geoipClient.js';
+
+let server;
+let sockDir;
+let socketPath;
+
+beforeAll(async () => {
+  sockDir = await mkdtemp(path.join(os.tmpdir(), 'geoip-test-'));
+  socketPath = path.join(sockDir, 'geoip2.sock');
+  server = http.createServer((req, res) => {
+    const url = new URL(req.url, 'http://localhost');
+    const ip = url.searchParams.get('ip');
+    if (ip === '8.8.8.8') {
+      res.writeHead(200, {'content-type': 'application/json'});
+      res.end(JSON.stringify({country: {iso_code: 'US'}, location: {time_zone: 'America/Chicago'}}));
+    } else if (ip === '0.0.0.0') {
+      res.writeHead(204); // not found
+      res.end();
+    } else {
+      res.writeHead(400);
+      res.end('{"error":"invalid ip"}');
+    }
+  });
+  await new Promise((resolve) => server.listen(socketPath, resolve));
+});
+
+afterAll(async () => {
+  await new Promise((resolve) => server.close(resolve));
+  await rm(sockDir, {recursive: true, force: true});
+});
+
+test('returns parsed record for a known IP', async () => {
+  const client = makeGeoipClient({socketPath});
+  const rec = await client.lookup('8.8.8.8');
+  expect(rec).toEqual({country: {iso_code: 'US'}, location: {time_zone: 'America/Chicago'}});
+});
+
+test('returns null for a 204 not-found response', async () => {
+  const client = makeGeoipClient({socketPath});
+  expect(await client.lookup('0.0.0.0')).toBe(null);
+});
+
+test('returns null for a non-200 response', async () => {
+  const client = makeGeoipClient({socketPath});
+  expect(await client.lookup('not-an-ip')).toBe(null);
+});
+
+test('returns null for empty input without contacting the service', async () => {
+  const client = makeGeoipClient({socketPath});
+  expect(await client.lookup('')).toBe(null);
+});
+
+test('falls back to null when the service is down (no socket)', async () => {
+  const client = makeGeoipClient({socketPath: path.join(sockDir, 'does-not-exist.sock')});
+  expect(await client.lookup('8.8.8.8')).toBe(null);
+});
+
+test('reuses keep-alive connections across lookups', async () => {
+  const client = makeGeoipClient({socketPath});
+  for (let i = 0; i < 5; i++) {
+    expect(await client.lookup('8.8.8.8')).toBeTruthy();
+  }
+});

--- a/test/location.test.js
+++ b/test/location.test.js
@@ -2,7 +2,8 @@ import {expect, test} from 'vitest';
 import {getLocationFromGeoIp} from '../src/location.js';
 
 /**
- * Minimal Koa-like ctx with a `get(header)` accessor and a geoipCity lookup.
+ * Minimal Koa-like ctx with a `get(header)` accessor and a geoipClient that
+ * resolves to the supplied lookup result (mimicking the hebcal-geoip2 service).
  * @param {string} userAgent
  * @param {any} geoipResult
  * @return {any}
@@ -10,7 +11,7 @@ import {getLocationFromGeoIp} from '../src/location.js';
 function makeCtx(userAgent, geoipResult) {
   const headers = {'user-agent': userAgent};
   return {
-    geoipCity: {get: () => geoipResult},
+    geoipClient: {lookup: async () => geoipResult},
     get(name) {
       return headers[name.toLowerCase()] || '';
     },
@@ -18,28 +19,34 @@ function makeCtx(userAgent, geoipResult) {
   };
 }
 
-test('getLocationFromGeoIp returns none for robot user-agent', () => {
+test('getLocationFromGeoIp returns none for robot user-agent', async () => {
   const ctx = makeCtx('curl', {country: {iso_code: 'US'}});
-  expect(getLocationFromGeoIp(ctx)).toEqual({geo: 'none'});
+  expect(await getLocationFromGeoIp(ctx)).toEqual({geo: 'none'});
 });
 
-test('getLocationFromGeoIp returns none for bot-like user-agent', () => {
+test('getLocationFromGeoIp returns none for bot-like user-agent', async () => {
   const ctx = makeCtx('Mozilla/5.0 (compatible; Googlebot/2.1)', {country: {iso_code: 'US'}});
-  expect(getLocationFromGeoIp(ctx)).toEqual({geo: 'none'});
+  expect(await getLocationFromGeoIp(ctx)).toEqual({geo: 'none'});
 });
 
-test('getLocationFromGeoIp returns none for blank or undefined user-agent', () => {
+test('getLocationFromGeoIp returns none for blank or undefined user-agent', async () => {
   const ctx = makeCtx('', {country: {iso_code: 'MX'}});
-  expect(getLocationFromGeoIp(ctx)).toEqual({geo: 'none'});
+  expect(await getLocationFromGeoIp(ctx)).toEqual({geo: 'none'});
   const ctx2 = makeCtx(undefined, {country: {iso_code: 'MX'}});
-  expect(getLocationFromGeoIp(ctx2)).toEqual({geo: 'none'});
+  expect(await getLocationFromGeoIp(ctx2)).toEqual({geo: 'none'});
 });
 
+test('getLocationFromGeoIp returns none when geoip client is absent', async () => {
+  const ua = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36';
+  const ctx = makeCtx(ua, {country: {iso_code: 'US'}});
+  delete ctx.geoipClient;
+  expect(await getLocationFromGeoIp(ctx)).toEqual({geo: 'none'});
+});
 
-test('getLocationFromGeoIp does not short-circuit for human user-agent', () => {
+test('getLocationFromGeoIp does not short-circuit for human user-agent', async () => {
   const ua = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36';
   const ctx = makeCtx(ua, null);
-  // geoip lookup returns null -> {geo: 'none'}, but this exercises the
-  // non-robot path (does not throw, falls through past the isRobot check).
-  expect(getLocationFromGeoIp(ctx)).toEqual({geo: 'none'});
+  // service returns null (unknown IP or unreachable) -> {geo: 'none'}, but this
+  // exercises the non-robot path (does not throw, falls through past isRobot).
+  expect(await getLocationFromGeoIp(ctx)).toEqual({geo: 'none'});
 });


### PR DESCRIPTION
## Summary

Replaces in-process MaxMind GeoIP database lookups with calls to the standalone [hebcal-geoip2](https://github.com/hebcal/hebcal-geoip2) Go microservice. This reduces heap memory usage by ~63 MB (the size of GeoLite2-City.mmdb) while maintaining the same geolocation functionality.

## Key Changes

- **New `src/geoipClient.js`**: HTTP client for the hebcal-geoip2 microservice
  - Supports both Unix domain sockets (default) and TCP connections
  - Implements aggressive timeouts (20 ms connect, 250 ms request) for fast failure
  - Gracefully falls back to `null` if the service is unreachable or slow
  - Reuses keep-alive connections across lookups
  - Includes optional pino-style logger for debug diagnostics

- **Refactored `src/geoip.js`**: Renamed `openGeoIpDbs()` → `setupGeoIp()`
  - Initializes the geoip client instead of loading the in-process database
  - Reads socket path and optional TCP host/port from `hebcal-dot-com.ini`
  - Logs connection details at startup

- **Updated `src/location.js`**: Made `getLocationFromGeoIp()` and `getLocationFromQueryOrGeoIp()` async
  - Now calls `ctx.geoipClient.lookup(ip)` instead of `ctx.geoipCity.get(ip)`
  - Returns `{geo: 'none'}` if the client is absent or the lookup fails

- **Updated callers**: Made async where needed
  - `src/defaultLangTz.js`: `setDefautLangTz()` is now async
  - `src/shabbat.js`: `geoIpRedirect()` is now async
  - `src/fridge.js`: `fridgeIndex()` is now async
  - `src/homepage.js`, `src/parshaIndex.js`, `src/converter.js`: await `setDefautLangTz()`

- **Removed dependency**: `maxmind` package no longer needed

- **Updated tests**: `test/location.test.js` now mocks `geoipClient.lookup()` instead of `geoipCity.get()`

- **New test**: `test/geoipClient.test.js` validates the client with a mock HTTP server

- **Documentation**: Updated `CLAUDE.md` to explain the new architecture

## Implementation Details

The geoip client uses a promise-based API that never rejects—all errors (connection timeouts, service errors, malformed responses) resolve to `null`. This ensures GeoIP is truly best-effort: if the microservice is slow or down, the request handler falls back gracefully without blocking the response.

The client manages a single `http.Agent` with keep-alive enabled (`maxSockets: 64, maxFreeSockets: 16`) to efficiently reuse connections across multiple lookups.

https://claude.ai/code/session_01JdsEBnay9JZScamV9AodLM