### PR TITLE
Add input validation hints and require date-entry fields

### DIFF
--- a/views/converter.ejs
+++ b/views/converter.ejs
@@ -91,7 +91,7 @@ const isPast = hy < todayHebYear;
 <form class="row gy-1 gx-2 mb-3 align-items-center" method="get" autocomplete="off" action="/converter" target="_top">
 <h5>Convert from Gregorian to Hebrew</h5>
 <div class="form-floating col-auto mb-2">
-<input type="text" inputmode="numeric" class="form-control" name="gd" placeholder="day" value="<%= gd %>" size="2" maxlength="2" id="gd" pattern="\d*">
+<input type="text" inputmode="numeric" class="form-control" name="gd" placeholder="day" value="<%= gd %>" size="2" maxlength="2" id="gd" pattern="\d*" title="Enter a day of the month between 1 and 31">
 <label for="gd">Day</label>
 </div><!-- .col -->
 <div class="form-floating col-auto mb-2">
@@ -112,7 +112,7 @@ const isPast = hy < todayHebYear;
 <label for="gm">Month</label>
 </div><!-- .col -->
 <div class="form-floating col-auto mb-2">
-<input type="text" inputmode="numeric" class="form-control" name="gy" placeholder="year" value="<%= gy %>" size="5" maxlength="5" id="gy" pattern="-?\d*">
+<input type="text" inputmode="numeric" class="form-control" name="gy" placeholder="year" value="<%= gy %>" size="5" maxlength="5" id="gy" pattern="-?\d*" title="Enter a year; use a leading minus sign for years BCE">
 <label for="gy">Year</label>
 </div><!-- .col -->
 <div class="col-auto mb-2">

--- a/views/converter.ejs
+++ b/views/converter.ejs
@@ -91,7 +91,7 @@ const isPast = hy < todayHebYear;
 <form class="row gy-1 gx-2 mb-3 align-items-center" method="get" autocomplete="off" action="/converter" target="_top">
 <h5>Convert from Gregorian to Hebrew</h5>
 <div class="form-floating col-auto mb-2">
-<input type="text" inputmode="numeric" class="form-control" name="gd" placeholder="day" value="<%= gd %>" size="2" maxlength="2" id="gd" pattern="\d*" title="Enter a day of the month between 1 and 31">
+<input type="text" inputmode="numeric" class="form-control" required name="gd" placeholder="day" value="<%= gd %>" size="2" maxlength="2" id="gd" pattern="\d*" title="Enter a day of the month between 1 and 31">
 <label for="gd">Day</label>
 </div><!-- .col -->
 <div class="form-floating col-auto mb-2">
@@ -112,7 +112,7 @@ const isPast = hy < todayHebYear;
 <label for="gm">Month</label>
 </div><!-- .col -->
 <div class="form-floating col-auto mb-2">
-<input type="text" inputmode="numeric" class="form-control" name="gy" placeholder="year" value="<%= gy %>" size="5" maxlength="5" id="gy" pattern="-?\d*" title="Enter a year; use a leading minus sign for years BCE">
+<input type="text" inputmode="numeric" class="form-control" required name="gy" placeholder="year" value="<%= gy %>" size="5" maxlength="5" id="gy" pattern="-?\d*" title="Enter a year; use a leading minus sign for years BCE">
 <label for="gy">Year</label>
 </div><!-- .col -->
 <div class="col-auto mb-2">

--- a/views/holidayDetail.ejs
+++ b/views/holidayDetail.ejs
@@ -130,7 +130,7 @@ is forbidden.</p>
 <label for="gy">Look up the date of <%=holiday%> in a past or future year</label>
 <div class="row gx-2 mb-3">
 <div class="col-auto mb-2">
-<input type="text" inputmode="numeric" class="form-control" required name="gy" id="gy" placeholder="1970" size="5" maxlength="4" pattern="\d*" title="Enter a year, for example 1970">
+<input type="text" inputmode="numeric" class="form-control" required name="gy" id="gy" placeholder="1970" size="5" maxlength="4" pattern="\d*" enterkeyhint="go" title="Enter a year, for example 1970">
 </div><!-- .col -->
 <div class="col-auto mb-2">
 <button type="submit" class="btn btn-primary">Go</button>

--- a/views/holidayDetail.ejs
+++ b/views/holidayDetail.ejs
@@ -130,7 +130,7 @@ is forbidden.</p>
 <label for="gy">Look up the date of <%=holiday%> in a past or future year</label>
 <div class="row gx-2 mb-3">
 <div class="col-auto mb-2">
-<input type="text" inputmode="numeric" class="form-control" required name="gy" id="gy" placeholder="1970" size="5" maxlength="4" pattern="\d*">
+<input type="text" inputmode="numeric" class="form-control" required name="gy" id="gy" placeholder="1970" size="5" maxlength="4" pattern="\d*" title="Enter a year, for example 1970">
 </div><!-- .col -->
 <div class="col-auto mb-2">
 <button type="submit" class="btn btn-primary">Go</button>

--- a/views/parsha-detail.ejs
+++ b/views/parsha-detail.ejs
@@ -251,7 +251,7 @@ Parashat <%=parshaName%> is read in <%=locationName%> on:
 <label for="gy">Look up the date of Parashat <%=parshaName%> in a past or future year</label>
 <div class="row gx-2 mb-3">
 <div class="col-auto mb-2">
-<input type="text" inputmode="numeric" class="form-control" required name="gy" id="gy" placeholder="1970" size="5" maxlength="4" pattern="\d*">
+<input type="text" inputmode="numeric" class="form-control" required name="gy" id="gy" placeholder="1970" size="5" maxlength="4" pattern="\d*" title="Enter a year, for example 1970">
 </div><!-- .col -->
 <% if (il) { %><input type="hidden" name="i" value="on"><%}%>
 <div class="col-auto mb-2">

--- a/views/parsha-detail.ejs
+++ b/views/parsha-detail.ejs
@@ -251,7 +251,7 @@ Parashat <%=parshaName%> is read in <%=locationName%> on:
 <label for="gy">Look up the date of Parashat <%=parshaName%> in a past or future year</label>
 <div class="row gx-2 mb-3">
 <div class="col-auto mb-2">
-<input type="text" inputmode="numeric" class="form-control" required name="gy" id="gy" placeholder="1970" size="5" maxlength="4" pattern="\d*" title="Enter a year, for example 1970">
+<input type="text" inputmode="numeric" class="form-control" required name="gy" id="gy" placeholder="1970" size="5" maxlength="4" pattern="\d*" enterkeyhint="go" title="Enter a year, for example 1970">
 </div><!-- .col -->
 <% if (il) { %><input type="hidden" name="i" value="on"><%}%>
 <div class="col-auto mb-2">

--- a/views/partials/city-and-havdalah.ejs
+++ b/views/partials/city-and-havdalah.ejs
@@ -21,7 +21,7 @@
 </div><!-- .form-check -->
 </div><!-- .col-auto --> 
 <div class="col-auto">
-  <input class="form-control" inputmode="decimal" type="text" name="td" value="<%=q.td||''%>" size="4" maxlength="8" id="td" pattern="\d{1,2}(\.\d+)?">
+  <input class="form-control" inputmode="decimal" type="text" name="td" value="<%=q.td||''%>" size="4" maxlength="8" id="td" pattern="\d{1,2}(\.\d+)?" title="Enter degrees below the horizon, for example 8.5">
 </div>
 <div class="col-auto" style="margin: auto 0">
   <span title="Use 7.083 degrees below the horizon for three medium-sized stars, 8.5 for three small stars, 16.1 for Rabbeinu Tam" data-bs-toggle="tooltip" data-bs-animation="false" data-bs-placement="top"><svg class="icon icon-sm mt-n1"><use href="<%=spriteHref%>#bi-info-circle-fill"></use></svg></span>
@@ -35,7 +35,7 @@
 </div><!-- .form-check -->
 </div><!-- .col-auto -->
 <div class="col-auto">
-  <input class="form-control" inputmode="numeric" type="text" name="m" value="<%= q.m || '' %>" size="2" maxlength="2" id="m" pattern="\d*">
+  <input class="form-control" inputmode="numeric" type="text" name="m" value="<%= q.m || '' %>" size="2" maxlength="2" id="m" pattern="\d*" title="Enter a number between 0 and 99">
 </div>
 <div class="col-auto" style="margin: auto 0">
   <span title="Use 42 min for three medium-sized stars, 50 min for three small stars, 72 min for Rabbeinu Tam, or 0 to suppress Havdalah times" data-bs-toggle="tooltip" data-bs-animation="false" data-bs-placement="top"><svg class="icon icon-sm mt-n1"><use href="<%=spriteHref%>#bi-info-circle-fill"></use></svg></span>

--- a/views/partials/hebcal-form.ejs
+++ b/views/partials/hebcal-form.ejs
@@ -14,7 +14,7 @@ if (typeof year !== 'string' || year.length === 0) {
     year = q.yt === 'H' || defaultYearInfo.isHebrewYear ? defaultYearInfo.hy : defaultYearInfo.gregRange;
   }
 } %>
-<input type="text" inputmode="numeric" name="year" value="<%= year %>" size="4" maxlength="4" class="form-control" id="year" pattern="-?\d*" placeholder="Year">
+<input type="text" inputmode="numeric" name="year" value="<%= year %>" size="4" maxlength="4" class="form-control" id="year" pattern="-?\d*" placeholder="Year" title="Enter a Gregorian or Hebrew year, for example 2026 or 5786">
 <label for="year">Year</label>
 </div><!-- .form-floating -->
 <div class="col-auto">
@@ -148,7 +148,7 @@ if (typeof year !== 'string' || year.length === 0) {
 </div>
 <div class="row gx-2 mb-3">
   <div class="col-auto">
-    <input class="form-control" inputmode="numeric" type="text" name="b" value="<%= q.b %>" size="2" maxlength="2" id="b1" pattern="\d*">
+    <input class="form-control" inputmode="numeric" type="text" name="b" value="<%= q.b %>" size="2" maxlength="2" id="b1" pattern="\d*" title="Enter a number between 0 and 99">
   </div>
   <label class="col-auto col-form-label" for="b1">minutes before sundown</label>
 </div>
@@ -161,7 +161,7 @@ if (typeof year !== 'string' || year.length === 0) {
 </div><!-- .form-check -->
 </div><!-- .col-auto -->
 <div class="col-auto">
-  <input class="form-control" inputmode="decimal" type="text" name="td" value="<%=q.td||''%>" size="4" maxlength="8" id="td" pattern="\d{1,2}(\.\d+)?">
+  <input class="form-control" inputmode="decimal" type="text" name="td" value="<%=q.td||''%>" size="4" maxlength="8" id="td" pattern="\d{1,2}(\.\d+)?" title="Enter degrees below the horizon, for example 8.5">
 </div>
 <div class="col-auto" style="margin: auto 0">
   <span title="Use 7.083 degrees below the horizon for three medium-sized stars, 8.5 for three small stars, 16.1 for Rabbeinu Tam" data-bs-toggle="tooltip" data-bs-animation="false" data-bs-placement="top"><svg class="icon icon-sm mt-n1"><use href="<%=spriteHref%>#bi-info-circle-fill"></use></svg></span>
@@ -175,7 +175,7 @@ if (typeof year !== 'string' || year.length === 0) {
 </div><!-- .form-check -->
 </div><!-- .col-auto -->
 <div class="col-auto">
-  <input class="form-control" inputmode="numeric" type="text" name="m" value="<%= q.m || '' %>" size="2" maxlength="2" id="m" pattern="\d*">
+  <input class="form-control" inputmode="numeric" type="text" name="m" value="<%= q.m || '' %>" size="2" maxlength="2" id="m" pattern="\d*" title="Enter a number between 0 and 99">
 </div>
 <div class="col-auto" style="margin: auto 0">
   <span title="Use 42 min for three medium-sized stars, 50 min for three small stars, 72 min for Rabbeinu Tam, or 0 to suppress Havdalah times" data-bs-toggle="tooltip" data-bs-animation="false" data-bs-placement="top"><svg class="icon icon-sm mt-n1"><use href="<%=spriteHref%>#bi-info-circle-fill"></use></svg></span>

--- a/views/partials/hebdate-picker.ejs
+++ b/views/partials/hebdate-picker.ejs
@@ -1,5 +1,5 @@
 <div class="form-floating col-auto mb-2">
-<input type="text" inputmode="numeric" class="form-control" name="hd<%=suffix%>" placeholder="day" value="<%= hd %>" size="2" maxlength="2" id="hd<%=suffix%>" pattern="\d*" title="Enter a day of the month between 1 and 30">
+<input type="text" inputmode="numeric" class="form-control" required name="hd<%=suffix%>" placeholder="day" value="<%= hd %>" size="2" maxlength="2" id="hd<%=suffix%>" pattern="\d*" title="Enter a day of the month between 1 and 30">
 <label for="hd<%=suffix%>">Day</label>
 </div><!-- /hd<%=suffix%> -->
 <div class="form-floating col-auto mb-2">
@@ -22,6 +22,6 @@
 <label for="hm<%=suffix%>">Month</label>
 </div><!-- /hm<%=suffix%> -->
 <div class="form-floating col-auto mb-2">
-<input type="text" inputmode="numeric" class="form-control" name="hy<%=suffix%>" placeholder="year" value="<%= hy %>" size="4" maxlength="4" id="hy<%=suffix%>" pattern="\d*" title="Enter a Hebrew year, for example 5786">
+<input type="text" inputmode="numeric" class="form-control" required name="hy<%=suffix%>" placeholder="year" value="<%= hy %>" size="4" maxlength="4" id="hy<%=suffix%>" pattern="\d*" title="Enter a Hebrew year, for example 5786">
 <label for="hy<%=suffix%>">Year</label>
 </div><!-- /hy<%=suffix%> -->

--- a/views/partials/hebdate-picker.ejs
+++ b/views/partials/hebdate-picker.ejs
@@ -1,5 +1,5 @@
 <div class="form-floating col-auto mb-2">
-<input type="text" inputmode="numeric" class="form-control" name="hd<%=suffix%>" placeholder="day" value="<%= hd %>" size="2" maxlength="2" id="hd<%=suffix%>" pattern="\d*">
+<input type="text" inputmode="numeric" class="form-control" name="hd<%=suffix%>" placeholder="day" value="<%= hd %>" size="2" maxlength="2" id="hd<%=suffix%>" pattern="\d*" title="Enter a day of the month between 1 and 30">
 <label for="hd<%=suffix%>">Day</label>
 </div><!-- /hd<%=suffix%> -->
 <div class="form-floating col-auto mb-2">
@@ -22,6 +22,6 @@
 <label for="hm<%=suffix%>">Month</label>
 </div><!-- /hm<%=suffix%> -->
 <div class="form-floating col-auto mb-2">
-<input type="text" inputmode="numeric" class="form-control" name="hy<%=suffix%>" placeholder="year" value="<%= hy %>" size="4" maxlength="4" id="hy<%=suffix%>" pattern="\d*">
+<input type="text" inputmode="numeric" class="form-control" name="hy<%=suffix%>" placeholder="year" value="<%= hy %>" size="4" maxlength="4" id="hy<%=suffix%>" pattern="\d*" title="Enter a Hebrew year, for example 5786">
 <label for="hy<%=suffix%>">Year</label>
 </div><!-- /hy<%=suffix%> -->

--- a/views/partials/navbar.ejs
+++ b/views/partials/navbar.ejs
@@ -39,7 +39,7 @@ if (rpath === '/') {
   <div class="collapse navbar-collapse d-print-none" id="navbarSupportedContent">
     <%- htmlMenu(rpath) %>
     <form class="d-flex d-print-none" role="search" method="get" id="searchform" action="/home/">
-      <input name="s" id="sitesearch" type="text" class="form-control me-2" placeholder="Search" aria-label="Search">
+      <input name="s" id="sitesearch" type="text" class="form-control me-2" placeholder="Search" aria-label="Search" enterkeyhint="search">
     </form>
   </div>
 </div>

--- a/views/partials/yahrzeit-row.ejs
+++ b/views/partials/yahrzeit-row.ejs
@@ -10,7 +10,7 @@
  <option <%= (q['t'+num] === 'Other') ? 'selected' : '' %>>Other</option>
 </select>
 <label class="form-label" for="t<%=num%>">Type</label></div>
-<div class="col-auto form-floating"><input class="form-control" type="text" inputmode="numeric" name="d<%=num%>" id="d<%=num%>" value="<%= q['d'+num] || '' %>" size="2" maxlength="2" max="31" min="1" pattern="\d*" placeholder="Day">
+<div class="col-auto form-floating"><input class="form-control" type="text" inputmode="numeric" name="d<%=num%>" id="d<%=num%>" value="<%= q['d'+num] || '' %>" size="2" maxlength="2" max="31" min="1" pattern="\d*" placeholder="Day" title="Enter a day of the month between 1 and 31">
 <label class="form-label" for="d<%=num%>">Day</label>
 <div class="invalid-feedback">Please enter a valid day of month.</div>
 </div>
@@ -29,7 +29,7 @@
  <option <%= q['m'+num] == 12 ? 'selected' : '' %> value="12">12-Dec</option>
 </select>
 <label class="form-label" for="m<%=num%>">Month</label></div>
-<div class="col-auto form-floating"><input class="form-control" type="text" inputmode="numeric" name="y<%=num%>" id="y<%=num%>" value="<%= q['y'+num] || '' %>" size="4" maxlength="4" pattern="\d*" placeholder="Year">
+<div class="col-auto form-floating"><input class="form-control" type="text" inputmode="numeric" name="y<%=num%>" id="y<%=num%>" value="<%= q['y'+num] || '' %>" size="4" maxlength="4" pattern="\d*" placeholder="Year" title="Enter a year, for example 1970">
 <label class="form-label" for="y<%=num%>">Year</label>
 <div class="invalid-feedback">Please enter a valid Gregorian year.</div>
 </div>

--- a/views/shabbat-browse.ejs
+++ b/views/shabbat-browse.ejs
@@ -18,7 +18,7 @@
   <input type="hidden" name="zip" id="zip">
   <label class="visually-hidden" for="city-typeahead">City</label>
   <div>
-    <input type="text" id="city-typeahead" class="form-control form-control-lg" placeholder="Search for city or ZIP code">
+    <input type="text" id="city-typeahead" class="form-control form-control-lg" placeholder="Search for city or ZIP code" enterkeyhint="search">
   </div>
 </form>
 </div><!-- .col-sm-10 -->

--- a/views/yahrzeit.ejs
+++ b/views/yahrzeit.ejs
@@ -177,7 +177,7 @@ data-count="<%=count%>" data-sprite-href="<%=spriteHref%>">
 <div class="row gx-2 mb-3 align-items-center">
   <label class="col-auto col-form-label" for="years">Number of years:</label>
   <div class="col-auto">
-    <input type="text" inputmode="numeric" name="years" value="<%= q.years %>" size="2" maxlength="2" class="form-control" id="years" max="99" min="1" pattern="\d*">
+    <input type="text" inputmode="numeric" name="years" value="<%= q.years %>" size="2" maxlength="2" class="form-control" id="years" max="99" min="1" pattern="\d*" title="Enter a number between 1 and 99">
   </div>
 </div>
 </div><!-- .clearfix -->


### PR DESCRIPTION
Improves the HTML form-validation experience on the numeric/date input fields, using only built-in browser tooltips (no custom JS/Bootstrap `invalid-feedback` styling).

## Changes

**`title` attributes on `pattern` inputs** — every numeric/decimal text input with a `pattern` but no `title` now has a human-readable hint that browsers surface as the validation tooltip when the pattern check fails. Follows the recently-added `title="Enter a number between 0 and 99"` example.
- Converter (Gregorian day/year, Hebrew day/year), holiday & parsha year lookups, yahrzeit years/day/year, and the Hebcal calendar + Shabbat candle-lighting/Havdalah forms (minutes and degrees).

**`enterkeyhint` on single-field lookup forms** — labels the mobile virtual-keyboard action key: `enterkeyhint="go"` on the holiday and parsha year-lookup forms (submit via a "Go" button), and `enterkeyhint="search"` on the navbar site search and the Shabbat city/ZIP lookup.

**`required` on date-entry day/year fields** — the Gregorian day/year (`converter.ejs`) and Hebrew day/year (`hebdate-picker.ejs`) inputs. Previously a partially-filled date (e.g. year and month set but day blank) fell through to the server and produced an HTTP 400; now the browser prompts before submit. Left on the optional settings fields (candle-lighting minutes, degrees, etc.) where empty legitimately means "use the default". `pattern` strings are unchanged — `pattern` is not evaluated against an empty value, so it never governed this case.

`type` and `inputmode` are unchanged throughout.

## Testing

Full build + `npm test`: 465 passed, 8 skipped.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NtkbF1SJkJDGXmpTT13jmC)_