### PR TITLE
Add client-side form validation for numeric input ranges

### DIFF
--- a/views/converter.ejs
+++ b/views/converter.ejs
@@ -91,7 +91,7 @@ const isPast = hy < todayHebYear;
 <form class="row gy-1 gx-2 mb-3 align-items-center" method="get" autocomplete="off" action="/converter" target="_top">
 <h5>Convert from Gregorian to Hebrew</h5>
 <div class="form-floating col-auto mb-2">
-<input type="text" inputmode="numeric" class="form-control" required name="gd" placeholder="day" value="<%= gd %>" size="2" maxlength="2" id="gd" pattern="\d*" title="Enter a day of the month between 1 and 31">
+<input type="text" inputmode="numeric" class="form-control" required name="gd" placeholder="day" value="<%= gd %>" size="2" maxlength="2" min="1" max="31" id="gd" pattern="\d*" title="Enter a day of the month between 1 and 31">
 <label for="gd">Day</label>
 </div><!-- .col -->
 <div class="form-floating col-auto mb-2">

--- a/views/converter.ejs
+++ b/views/converter.ejs
@@ -152,6 +152,63 @@ const isPast = hy < todayHebYear;
 </div><!-- .col-md -->
 </div><!-- .row -->
 </div><!-- #converter-form -->
+<script nonce="<%=nonce%>">
+document.addEventListener("DOMContentLoaded", function() {
+  const forms = document.querySelectorAll("#converter-form form");
+  function checkRange(el) {
+    if (!el) {
+      return;
+    }
+    el.setCustomValidity("");
+    if (el.value === "") {
+      return;
+    }
+    const num = Number(el.value);
+    if (Number.isNaN(num)) {
+      return;
+    }
+    const min = el.min === "" ? null : Number(el.min);
+    const max = el.max === "" ? null : Number(el.max);
+    if ((min !== null && num < min) || (max !== null && num > max)) {
+      el.setCustomValidity(el.title || "Please enter a value in the valid range");
+    }
+  }
+  forms.forEach(function(form) {
+    const gd = form.querySelector("#gd");
+    const gy = form.querySelector("#gy");
+    const hd = form.querySelector("#hd");
+    const hy = form.querySelector("#hy");
+    const nums = [gd, gy, hd, hy].filter(Boolean);
+    // Clear any custom range error as soon as the form is edited, so a
+    // corrected value can be resubmitted (setCustomValidity persists otherwise).
+    form.addEventListener("input", function() {
+      nums.forEach(function(el) {
+        el.setCustomValidity("");
+      });
+    });
+    form.addEventListener("submit", function(event) {
+      nums.forEach(checkRange);
+      // Gregorian: reject days that don't exist in the selected month/year
+      if (gd && gd.validity.valid) {
+        const gm = form.querySelector("#gm");
+        const dd = Number(gd.value);
+        const mm = gm ? Number(gm.value) : NaN;
+        const yy = gy ? Number(gy.value) : NaN;
+        if (yy >= 100 && !Number.isNaN(dd) && !Number.isNaN(mm)) {
+          const maxDay = new Date(yy, mm, 0).getDate();
+          if (dd > maxDay) {
+            gd.setCustomValidity("Day " + dd + " is out of range for the selected month");
+          }
+        }
+      }
+      if (!form.reportValidity()) {
+        event.preventDefault();
+        event.stopPropagation();
+      }
+    });
+  });
+});
+</script>
 
 <div class="d-flex justify-content-center d-print-none">
 <h6 class="text-body-secondary mt-2 mb-1">Advertisement</h6>

--- a/views/partials/city-and-havdalah.ejs
+++ b/views/partials/city-and-havdalah.ejs
@@ -8,7 +8,7 @@
 </div>
 <div class="row gx-2 mb-3">
   <div class="col-auto">
-    <input class="form-control" inputmode="numeric" type="text" name="b" value="<%= q.b || 18 %>" size="2" maxlength="2" id="b1" pattern="\d{1,2}" title="Enter a number between 0 and 99">
+    <input class="form-control" inputmode="numeric" type="text" name="b" value="<%= q.b || 18 %>" size="2" maxlength="2" min="0" max="99" id="b1" pattern="\d{1,2}" title="Enter a number between 0 and 99">
   </div>
   <label class="col-auto col-form-label" for="b1">minutes before sundown</label>
 </div>
@@ -21,7 +21,7 @@
 </div><!-- .form-check -->
 </div><!-- .col-auto --> 
 <div class="col-auto">
-  <input class="form-control" inputmode="decimal" type="text" name="td" value="<%=q.td||''%>" size="4" maxlength="8" id="td" pattern="\d{1,2}(\.\d+)?" title="Enter degrees below the horizon, for example 8.5">
+  <input class="form-control" inputmode="decimal" type="text" name="td" value="<%=q.td||''%>" size="4" maxlength="8" min="0" max="30" id="td" pattern="\d{1,2}(\.\d+)?" title="Enter degrees below the horizon, for example 8.5">
 </div>
 <div class="col-auto" style="margin: auto 0">
   <span title="Use 7.083 degrees below the horizon for three medium-sized stars, 8.5 for three small stars, 16.1 for Rabbeinu Tam" data-bs-toggle="tooltip" data-bs-animation="false" data-bs-placement="top"><svg class="icon icon-sm mt-n1"><use href="<%=spriteHref%>#bi-info-circle-fill"></use></svg></span>
@@ -35,7 +35,7 @@
 </div><!-- .form-check -->
 </div><!-- .col-auto -->
 <div class="col-auto">
-  <input class="form-control" inputmode="numeric" type="text" name="m" value="<%= q.m || '' %>" size="2" maxlength="2" id="m" pattern="\d*" title="Enter a number between 0 and 99">
+  <input class="form-control" inputmode="numeric" type="text" name="m" value="<%= q.m || '' %>" size="2" maxlength="2" min="0" max="99" id="m" pattern="\d*" title="Enter a number between 0 and 99">
 </div>
 <div class="col-auto" style="margin: auto 0">
   <span title="Use 42 min for three medium-sized stars, 50 min for three small stars, 72 min for Rabbeinu Tam, or 0 to suppress Havdalah times" data-bs-toggle="tooltip" data-bs-animation="false" data-bs-placement="top"><svg class="icon icon-sm mt-n1"><use href="<%=spriteHref%>#bi-info-circle-fill"></use></svg></span>

--- a/views/partials/hebcal-form.ejs
+++ b/views/partials/hebcal-form.ejs
@@ -148,7 +148,7 @@ if (typeof year !== 'string' || year.length === 0) {
 </div>
 <div class="row gx-2 mb-3">
   <div class="col-auto">
-    <input class="form-control" inputmode="numeric" type="text" name="b" value="<%= q.b %>" size="2" maxlength="2" id="b1" pattern="\d*" title="Enter a number between 0 and 99">
+    <input class="form-control" inputmode="numeric" type="text" name="b" value="<%= q.b %>" size="2" maxlength="2" min="0" max="99" id="b1" pattern="\d*" title="Enter a number between 0 and 99">
   </div>
   <label class="col-auto col-form-label" for="b1">minutes before sundown</label>
 </div>
@@ -161,7 +161,7 @@ if (typeof year !== 'string' || year.length === 0) {
 </div><!-- .form-check -->
 </div><!-- .col-auto -->
 <div class="col-auto">
-  <input class="form-control" inputmode="decimal" type="text" name="td" value="<%=q.td||''%>" size="4" maxlength="8" id="td" pattern="\d{1,2}(\.\d+)?" title="Enter degrees below the horizon, for example 8.5">
+  <input class="form-control" inputmode="decimal" type="text" name="td" value="<%=q.td||''%>" size="4" maxlength="8" min="0" max="30" id="td" pattern="\d{1,2}(\.\d+)?" title="Enter degrees below the horizon, for example 8.5">
 </div>
 <div class="col-auto" style="margin: auto 0">
   <span title="Use 7.083 degrees below the horizon for three medium-sized stars, 8.5 for three small stars, 16.1 for Rabbeinu Tam" data-bs-toggle="tooltip" data-bs-animation="false" data-bs-placement="top"><svg class="icon icon-sm mt-n1"><use href="<%=spriteHref%>#bi-info-circle-fill"></use></svg></span>
@@ -175,7 +175,7 @@ if (typeof year !== 'string' || year.length === 0) {
 </div><!-- .form-check -->
 </div><!-- .col-auto -->
 <div class="col-auto">
-  <input class="form-control" inputmode="numeric" type="text" name="m" value="<%= q.m || '' %>" size="2" maxlength="2" id="m" pattern="\d*" title="Enter a number between 0 and 99">
+  <input class="form-control" inputmode="numeric" type="text" name="m" value="<%= q.m || '' %>" size="2" maxlength="2" min="0" max="99" id="m" pattern="\d*" title="Enter a number between 0 and 99">
 </div>
 <div class="col-auto" style="margin: auto 0">
   <span title="Use 42 min for three medium-sized stars, 50 min for three small stars, 72 min for Rabbeinu Tam, or 0 to suppress Havdalah times" data-bs-toggle="tooltip" data-bs-animation="false" data-bs-placement="top"><svg class="icon icon-sm mt-n1"><use href="<%=spriteHref%>#bi-info-circle-fill"></use></svg></span>

--- a/views/partials/hebdate-picker.ejs
+++ b/views/partials/hebdate-picker.ejs
@@ -1,5 +1,5 @@
 <div class="form-floating col-auto mb-2">
-<input type="text" inputmode="numeric" class="form-control" required name="hd<%=suffix%>" placeholder="day" value="<%= hd %>" size="2" maxlength="2" id="hd<%=suffix%>" pattern="\d*" title="Enter a day of the month between 1 and 30">
+<input type="text" inputmode="numeric" class="form-control" required name="hd<%=suffix%>" placeholder="day" value="<%= hd %>" size="2" maxlength="2" min="1" max="30" id="hd<%=suffix%>" pattern="\d*" title="Enter a day of the month between 1 and 30">
 <label for="hd<%=suffix%>">Day</label>
 </div><!-- /hd<%=suffix%> -->
 <div class="form-floating col-auto mb-2">


### PR DESCRIPTION
## Summary
Enhance form validation by adding HTML5 `min` and `max` attributes to numeric input fields across multiple forms, and implement comprehensive client-side validation logic in the converter form to enforce range constraints and validate calendar-specific rules (e.g., days that don't exist in a given month).

## Changes

- **converter.ejs**: 
  - Added `min="1" max="31"` to Gregorian day input
  - Implemented new `<script>` block with form validation that:
    - Checks numeric ranges on form submission
    - Validates that Gregorian days exist in the selected month/year
    - Clears custom validation errors on input to allow resubmission
    - Uses `setCustomValidity()` and `reportValidity()` for native HTML5 validation UI

- **city-and-havdalah.ejs**:
  - Added `min="0" max="99"` to minutes before sundown input
  - Added `min="0" max="30"` to degrees below horizon input
  - Added `min="0" max="99"` to minutes (Havdalah time) input

- **hebcal-form.ejs**:
  - Added `min="0" max="99"` to minutes before sundown input
  - Added `min="0" max="30"` to degrees below horizon input
  - Added `min="0" max="99"` to minutes (Havdalah time) input

- **hebdate-picker.ejs**:
  - Added `min="1" max="30"` to Hebrew day input

## Implementation Details

The converter form validation script:
- Runs on DOM load and attaches listeners to all forms within `#converter-form`
- Validates numeric ranges using `min`/`max` attributes
- Performs calendar-aware validation: rejects invalid Gregorian dates (e.g., Feb 30)
- Clears validation state on user input to allow corrected values to be resubmitted
- Prevents form submission if validation fails via `event.preventDefault()`
- Uses the input's `title` attribute as the custom validation message

All changes maintain backward compatibility and enhance UX by providing immediate, browser-native validation feedback.

https://claude.ai/code/session_01NtkbF1SJkJDGXmpTT13jmC