### PR TITLE
Shared client-side range validation for year-lookup forms

### DIFF
--- a/views/converter.ejs
+++ b/views/converter.ejs
@@ -88,7 +88,7 @@ const isPast = hy < todayHebYear;
 <div id="converter-form" class="d-print-none mt-4">
 <div class="row">
 <div class="col-md">
-<form class="row gy-1 gx-2 mb-3 align-items-center" method="get" autocomplete="off" action="/converter" target="_top">
+<form class="row gy-1 gx-2 mb-3 align-items-center" method="get" autocomplete="off" action="/converter" target="_top" data-range-validate>
 <h5>Convert from Gregorian to Hebrew</h5>
 <div class="form-floating col-auto mb-2">
 <input type="text" inputmode="numeric" class="form-control" required name="gd" placeholder="day" value="<%= gd %>" size="2" maxlength="2" min="1" max="31" id="gd" pattern="\d*" title="Enter a day of the month between 1 and 31">
@@ -132,7 +132,7 @@ const isPast = hy < todayHebYear;
 </div><!-- .col-md -->
 
 <div class="col-md">
-<form class="row gy-1 gx-2 mb-3 align-items-center" method="get" autocomplete="off" action="/converter" target="_top">
+<form class="row gy-1 gx-2 mb-3 align-items-center" method="get" autocomplete="off" action="/converter" target="_top" data-range-validate>
 <h5>Convert from Hebrew to Gregorian</h5>
 <%- await include('partials/hebdate-picker.ejs', {
   hd: hd,
@@ -152,63 +152,7 @@ const isPast = hy < todayHebYear;
 </div><!-- .col-md -->
 </div><!-- .row -->
 </div><!-- #converter-form -->
-<script nonce="<%=nonce%>">
-document.addEventListener("DOMContentLoaded", function() {
-  const forms = document.querySelectorAll("#converter-form form");
-  function checkRange(el) {
-    if (!el) {
-      return;
-    }
-    el.setCustomValidity("");
-    if (el.value === "") {
-      return;
-    }
-    const num = Number(el.value);
-    if (Number.isNaN(num)) {
-      return;
-    }
-    const min = el.min === "" ? null : Number(el.min);
-    const max = el.max === "" ? null : Number(el.max);
-    if ((min !== null && num < min) || (max !== null && num > max)) {
-      el.setCustomValidity(el.title || "Please enter a value in the valid range");
-    }
-  }
-  forms.forEach(function(form) {
-    const gd = form.querySelector("#gd");
-    const gy = form.querySelector("#gy");
-    const hd = form.querySelector("#hd");
-    const hy = form.querySelector("#hy");
-    const nums = [gd, gy, hd, hy].filter(Boolean);
-    // Clear any custom range error as soon as the form is edited, so a
-    // corrected value can be resubmitted (setCustomValidity persists otherwise).
-    form.addEventListener("input", function() {
-      nums.forEach(function(el) {
-        el.setCustomValidity("");
-      });
-    });
-    form.addEventListener("submit", function(event) {
-      nums.forEach(checkRange);
-      // Gregorian: reject days that don't exist in the selected month/year
-      if (gd && gd.validity.valid) {
-        const gm = form.querySelector("#gm");
-        const dd = Number(gd.value);
-        const mm = gm ? Number(gm.value) : NaN;
-        const yy = gy ? Number(gy.value) : NaN;
-        if (yy >= 100 && !Number.isNaN(dd) && !Number.isNaN(mm)) {
-          const maxDay = new Date(yy, mm, 0).getDate();
-          if (dd > maxDay) {
-            gd.setCustomValidity("Day " + dd + " is out of range for the selected month");
-          }
-        }
-      }
-      if (!form.reportValidity()) {
-        event.preventDefault();
-        event.stopPropagation();
-      }
-    });
-  });
-});
-</script>
+<%- await include('partials/form-range-validation.ejs') -%>
 
 <div class="d-flex justify-content-center d-print-none">
 <h6 class="text-body-secondary mt-2 mb-1">Advertisement</h6>

--- a/views/holidayDetail.ejs
+++ b/views/holidayDetail.ejs
@@ -126,7 +126,7 @@ is forbidden.</p>
 </table>
 </div>
 <% if (holiday !== 'Asara B\'Tevet') { %>
-<form method="GET" action="/holidays/<%=holidayAnchor%>" target="_top">
+<form method="GET" action="/holidays/<%=holidayAnchor%>" target="_top" data-range-validate>
 <label for="gy">Look up the date of <%=holiday%> in a past or future year</label>
 <div class="row gx-2 mb-3">
 <div class="col-auto mb-2">
@@ -137,6 +137,7 @@ is forbidden.</p>
 </div><!-- .col -->
 </div>
 </form>
+<%- await include('partials/form-range-validation.ejs') -%>
 <% } %>
 
 <div class="d-flex justify-content-center d-print-none">

--- a/views/parsha-detail.ejs
+++ b/views/parsha-detail.ejs
@@ -247,7 +247,7 @@ Parashat <%=parshaName%> is read in <%=locationName%> on:
 <% } // items.length -%>
 <div class="row d-print-none">
 <div class="col">
-<form method="GET" action="/sedrot/<%=parsha.anchor%>">
+<form method="GET" action="/sedrot/<%=parsha.anchor%>" data-range-validate>
 <label for="gy">Look up the date of Parashat <%=parshaName%> in a past or future year</label>
 <div class="row gx-2 mb-3">
 <div class="col-auto mb-2">
@@ -259,6 +259,7 @@ Parashat <%=parshaName%> is read in <%=locationName%> on:
 </div><!-- .col -->
 </div>
 </form>
+<%- await include('partials/form-range-validation.ejs') -%>
 </div><!-- .col -->
 </div><!-- .d-print-none -->
 <div class="row">

--- a/views/partials/form-range-validation.ejs
+++ b/views/partials/form-range-validation.ejs
@@ -1,0 +1,53 @@
+<script nonce="<%=nonce%>">
+document.addEventListener("DOMContentLoaded", function() {
+  function checkRange(el) {
+    el.setCustomValidity("");
+    if (el.value === "") {
+      return;
+    }
+    const num = Number(el.value);
+    if (Number.isNaN(num)) {
+      return;
+    }
+    const min = el.min === "" ? null : Number(el.min);
+    const max = el.max === "" ? null : Number(el.max);
+    if ((min !== null && num < min) || (max !== null && num > max)) {
+      el.setCustomValidity(el.title || "Please enter a value in the valid range");
+    }
+  }
+  const forms = document.querySelectorAll("form[data-range-validate]");
+  forms.forEach(function(form) {
+    const ranged = [].slice.call(form.querySelectorAll("input[min], input[max]"));
+    // Clear any custom range error as soon as the form is edited, so a
+    // corrected value can be resubmitted (setCustomValidity persists otherwise).
+    form.addEventListener("input", function() {
+      ranged.forEach(function(el) {
+        el.setCustomValidity("");
+      });
+    });
+    form.addEventListener("submit", function(event) {
+      ranged.forEach(checkRange);
+      // When the form has a Gregorian day/month/year, also reject days that
+      // don't exist in the selected month/year (e.g. 30 February).
+      const gd = form.querySelector("#gd");
+      const gm = form.querySelector("#gm");
+      const gy = form.querySelector("#gy");
+      if (gd && gm && gy && gd.validity.valid) {
+        const dd = Number(gd.value);
+        const mm = Number(gm.value);
+        const yy = Number(gy.value);
+        if (yy >= 100 && !Number.isNaN(dd) && !Number.isNaN(mm)) {
+          const maxDay = new Date(yy, mm, 0).getDate();
+          if (dd > maxDay) {
+            gd.setCustomValidity("Day " + dd + " is out of range for the selected month");
+          }
+        }
+      }
+      if (!form.reportValidity()) {
+        event.preventDefault();
+        event.stopPropagation();
+      }
+    });
+  });
+});
+</script>


### PR DESCRIPTION
Follow-up to the converter validation (merged in #85). Extracts that logic into a reusable partial and applies it to the holiday and parsha year-lookup forms.

## Changes

- **New `views/partials/form-range-validation.ejs`** — a reusable script that wires up any form marked with `data-range-validate`:
  - Enforces each numeric input's `min`/`max` via `setCustomValidity` + `reportValidity` (uses the input's `title` as the message).
  - Clears the custom error on edit, so a corrected value can be resubmitted (`setCustomValidity` persists otherwise).
  - Applies a Gregorian days-in-month check when the form has `gd`/`gm`/`gy` (e.g. rejects 30 February).
- **`converter.ejs`** — the two converter forms now opt in via `data-range-validate` and include the shared partial, replacing the bespoke inline script (net removal of ~55 lines).
- **`holidayDetail.ejs`, `parsha-detail.ejs`** — the year-lookup forms opt in via `data-range-validate` and include the shared partial. Their `gy` inputs already carry `min="1000" max="2999"` (on `main`), so an out-of-range year is now caught inline instead of by the server.

`min`/`max` are not enforced natively on `type="text"` inputs, so this handler is what makes them effective. No `type`/`inputmode` changes.

## Testing

- Full build + `npm test`: 465 passed, 8 skipped.
- Verified in headless Chromium across all three pages: holiday/parsha block years <1000 and >2999 (boundaries 1000/2999 allowed) using the existing "Enter any Gregorian year 1000-2999" message; converter still blocks out-of-range days and non-existent dates (30 Feb) while allowing valid ones (29 Feb in a leap year); Hebrew day range (1–30) intact.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NtkbF1SJkJDGXmpTT13jmC)_