### PR TITLE
Suppress browser autofill and password-manager widgets on non-credential inputs

### DIFF
--- a/src/app-www.js
+++ b/src/app-www.js
@@ -37,6 +37,11 @@ const cspriteHref = '/i/' + pkg.config.csprite;
 const clientAppHref = '/i/' + pkg.config.clientapp;
 const holidayFcAppHref = '/i/' + pkg.config.holidayFcApp;
 const mainCssHref = '/i/' + pkg.config.mainCss;
+// Attributes that ask third-party password managers to ignore a field so
+// they don't offer an autofill widget on inputs like names, dates or years.
+// Pair with autocomplete="off" in the template. See EJS partials for usage.
+const pmIgnore = 'data-1p-ignore data-bwignore data-lpignore="true" ' +
+  'data-protonpass-ignore="true" data-form-type="other"';
 
 app.use(async function fixup0(ctx, next) {
   ctx.state.rpath = ctx.request.path; // used by some ejs templates
@@ -47,6 +52,7 @@ app.use(async function fixup0(ctx, next) {
     clientAppHref,
     holidayFcAppHref,
     mainCssHref,
+    pmIgnore,
   });
   ctx.state.hostname = HOSTNAME; // used by some ejs templates
   // don't allow compress middleware to assume that a missing

--- a/src/client-yahrzeit.js
+++ b/src/client-yahrzeit.js
@@ -11,18 +11,23 @@ function getCurrentCount() {
 }
 
 const spriteHref = mainFormEl.dataset.spriteHref;
+// Keep in sync with the `pmIgnore` local in src/app-www.js: ask third-party
+// password managers to ignore these fields so they don't offer an autofill
+// widget. Paired with autocomplete="off" on names and years below.
+const pmIgnore = 'data-1p-ignore data-bwignore data-lpignore="true" '+
+  'data-protonpass-ignore="true" data-form-type="other"';
 function yahrzeitRow(n) {
   return '<div class="row gy-1 gx-2 mb-3 align-items-center mt-1">'+
   '<div class="col-auto">'+n+'.</div>' +
   '<div class="col-auto form-floating">'+
-  '<input class="form-control" type="text" name="n'+n+'" id="n'+n+'" placeholder="Name">'+
+  '<input class="form-control" type="text" name="n'+n+'" id="n'+n+'" placeholder="Name" autocomplete="off" '+pmIgnore+'>'+
   '<label class="form-label" for="n'+n+'">Name</label></div>'+
   '<div class="col-auto form-floating"><select name="t'+n+'" id="t'+n+'" class="form-select">'+
   '<option>Yahrzeit</option><option>Birthday</option><option>Anniversary</option><option>Other</option></select>'+
   '<label class="form-label" for="t'+n+'">Type</label></div>'+
   '<div class="col-auto form-floating">'+
   '<input class="form-control" type="text" inputmode="numeric" name="d'+
-    n+'" id="d'+n+'" size="2" maxlength="2" max="31" min="1" pattern="\\d*" placeholder="Day">'+
+    n+'" id="d'+n+'" size="2" maxlength="2" max="31" min="1" pattern="\\d*" placeholder="Day" autocomplete="off">'+
   '<label class="form-label" for="d'+n+'">Day</label>'+
   '<div class="invalid-feedback">Please enter a valid day of month.</div>'+
   '</div>'+
@@ -35,7 +40,7 @@ function yahrzeitRow(n) {
   '<label class="form-label" for="m'+n+'">Month</label></div>'+
   '<div class="col-auto form-floating">'+
   '<input class="form-control" type="text" inputmode="numeric" name="y'+
-    n+'" id="y'+n+'" size="4" maxlength="4" pattern="\\d*" placeholder="Year">'+
+    n+'" id="y'+n+'" size="4" maxlength="4" pattern="\\d*" placeholder="Year" autocomplete="off" '+pmIgnore+'>'+
   '<label class="form-label" for="y'+n+'">Year</label>'+
   '<div class="invalid-feedback">Please enter a valid Gregorian year.</div>'+
   '</div>'+

--- a/views/converter.ejs
+++ b/views/converter.ejs
@@ -91,7 +91,7 @@ const isPast = hy < todayHebYear;
 <form class="row gy-1 gx-2 mb-3 align-items-center" method="get" autocomplete="off" action="/converter" target="_top" data-range-validate>
 <h5>Convert from Gregorian to Hebrew</h5>
 <div class="form-floating col-auto mb-2">
-<input type="text" inputmode="numeric" class="form-control" required name="gd" placeholder="day" value="<%= gd %>" size="2" maxlength="2" min="1" max="31" id="gd" pattern="\d*" title="Enter a day of the month between 1 and 31">
+<input type="text" inputmode="numeric" class="form-control" required name="gd" placeholder="day" value="<%= gd %>" size="2" maxlength="2" min="1" max="31" id="gd" pattern="\d*" title="Enter a day of the month between 1 and 31" autocomplete="off">
 <label for="gd">Day</label>
 </div><!-- .col -->
 <div class="form-floating col-auto mb-2">
@@ -112,7 +112,7 @@ const isPast = hy < todayHebYear;
 <label for="gm">Month</label>
 </div><!-- .col -->
 <div class="form-floating col-auto mb-2">
-<input type="text" inputmode="numeric" class="form-control" required name="gy" placeholder="year" value="<%= gy %>" size="5" maxlength="5" id="gy" pattern="-?\d*" title="Enter a year; use a leading minus sign for years BCE">
+<input type="text" inputmode="numeric" class="form-control" required name="gy" placeholder="year" value="<%= gy %>" size="5" maxlength="5" id="gy" pattern="-?\d*" title="Enter a year; use a leading minus sign for years BCE" autocomplete="off" <%- locals.pmIgnore || '' %>>
 <label for="gy">Year</label>
 </div><!-- .col -->
 <div class="col-auto mb-2">

--- a/views/holidayDetail.ejs
+++ b/views/holidayDetail.ejs
@@ -130,7 +130,7 @@ is forbidden.</p>
 <label for="gy">Look up the date of <%=holiday%> in a past or future year</label>
 <div class="row gx-2 mb-3">
 <div class="col-auto mb-2">
-<input type="text" inputmode="numeric" class="form-control" required name="gy" id="gy" placeholder="1970" size="5" maxlength="4" pattern="\d*" min="1000" max="2999" enterkeyhint="go" title="Enter any Gregorian year 1000-2999">
+<input type="text" inputmode="numeric" class="form-control" required name="gy" id="gy" placeholder="1970" size="5" maxlength="4" pattern="\d*" min="1000" max="2999" enterkeyhint="go" title="Enter any Gregorian year 1000-2999" autocomplete="off" <%- locals.pmIgnore || '' %>>
 </div><!-- .col -->
 <div class="col-auto mb-2">
 <button type="submit" class="btn btn-primary">Go</button>

--- a/views/parsha-detail.ejs
+++ b/views/parsha-detail.ejs
@@ -251,7 +251,7 @@ Parashat <%=parshaName%> is read in <%=locationName%> on:
 <label for="gy">Look up the date of Parashat <%=parshaName%> in a past or future year</label>
 <div class="row gx-2 mb-3">
 <div class="col-auto mb-2">
-<input type="text" inputmode="numeric" class="form-control" required name="gy" id="gy" placeholder="1970" size="5" maxlength="4" pattern="\d*" min="1000" max="2999" enterkeyhint="go" title="Enter any Gregorian year 1000-2999">
+<input type="text" inputmode="numeric" class="form-control" required name="gy" id="gy" placeholder="1970" size="5" maxlength="4" pattern="\d*" min="1000" max="2999" enterkeyhint="go" title="Enter any Gregorian year 1000-2999" autocomplete="off" <%- locals.pmIgnore || '' %>>
 </div><!-- .col -->
 <% if (il) { %><input type="hidden" name="i" value="on"><%}%>
 <div class="col-auto mb-2">

--- a/views/partials/city-and-havdalah.ejs
+++ b/views/partials/city-and-havdalah.ejs
@@ -2,7 +2,7 @@
 <div class="mb-3">
   <label class="form-label" for="city-typeahead">City</label>
   <div class="input-clear-wrapper">
-    <input type="text" value="<%= q['city-typeahead'] || '' %>" class="form-control" id="city-typeahead" autocomplete="off" placeholder="Search for city or ZIP code">
+    <input type="text" value="<%= q['city-typeahead'] || '' %>" class="form-control" id="city-typeahead" autocomplete="off" <%- locals.pmIgnore || '' %> placeholder="Search for city or ZIP code">
     <button type="button" class="btn-close" aria-label="Clear" id="clear-btn"></button>
   </div>
 </div>

--- a/views/partials/hebcal-form.ejs
+++ b/views/partials/hebcal-form.ejs
@@ -14,7 +14,7 @@ if (typeof year !== 'string' || year.length === 0) {
     year = q.yt === 'H' || defaultYearInfo.isHebrewYear ? defaultYearInfo.hy : defaultYearInfo.gregRange;
   }
 } %>
-<input type="text" inputmode="numeric" name="year" value="<%= year %>" size="4" maxlength="4" class="form-control" id="year" pattern="-?\d*" placeholder="Year" title="Enter a Gregorian or Hebrew year, for example 2026 or 5786">
+<input type="text" inputmode="numeric" name="year" value="<%= year %>" size="4" maxlength="4" class="form-control" id="year" pattern="-?\d*" placeholder="Year" title="Enter a Gregorian or Hebrew year, for example 2026 or 5786" autocomplete="off" <%- locals.pmIgnore || '' %>>
 <label for="year">Year</label>
 </div><!-- .form-floating -->
 <div class="col-auto">
@@ -142,7 +142,7 @@ if (typeof year !== 'string' || year.length === 0) {
 <input type="hidden" name="zip" value="<%= q.zip || '' %>" id="zip">
 <input type="hidden" name="geonameid" value="<%= q.geonameid || '' %>" id="geonameid">
   <div class="input-clear-wrapper">
-    <input type="text" value="<%= q['city-typeahead'] || '' %>" class="form-control" id="city-typeahead" autocomplete="off" placeholder="Search for city or ZIP code">
+    <input type="text" value="<%= q['city-typeahead'] || '' %>" class="form-control" id="city-typeahead" autocomplete="off" <%- locals.pmIgnore || '' %> placeholder="Search for city or ZIP code">
     <button type="button" class="btn-close" aria-label="Clear" id="clear-btn"></button>
   </div>
 </div>

--- a/views/partials/hebdate-picker.ejs
+++ b/views/partials/hebdate-picker.ejs
@@ -1,5 +1,5 @@
 <div class="form-floating col-auto mb-2">
-<input type="text" inputmode="numeric" class="form-control" required name="hd<%=suffix%>" placeholder="day" value="<%= hd %>" size="2" maxlength="2" min="1" max="30" id="hd<%=suffix%>" pattern="\d*" title="Enter a day of the month between 1 and 30">
+<input type="text" inputmode="numeric" class="form-control" required name="hd<%=suffix%>" placeholder="day" value="<%= hd %>" size="2" maxlength="2" min="1" max="30" id="hd<%=suffix%>" pattern="\d*" title="Enter a day of the month between 1 and 30" autocomplete="off">
 <label for="hd<%=suffix%>">Day</label>
 </div><!-- /hd<%=suffix%> -->
 <div class="form-floating col-auto mb-2">
@@ -22,6 +22,6 @@
 <label for="hm<%=suffix%>">Month</label>
 </div><!-- /hm<%=suffix%> -->
 <div class="form-floating col-auto mb-2">
-<input type="text" inputmode="numeric" class="form-control" required name="hy<%=suffix%>" placeholder="year" value="<%= hy %>" size="4" maxlength="4" id="hy<%=suffix%>" pattern="\d*" title="Enter a Hebrew year, for example 5786">
+<input type="text" inputmode="numeric" class="form-control" required name="hy<%=suffix%>" placeholder="year" value="<%= hy %>" size="4" maxlength="4" id="hy<%=suffix%>" pattern="\d*" title="Enter a Hebrew year, for example 5786" autocomplete="off" <%- locals.pmIgnore || '' %>>
 <label for="hy<%=suffix%>">Year</label>
 </div><!-- /hy<%=suffix%> -->

--- a/views/partials/yahrzeit-row.ejs
+++ b/views/partials/yahrzeit-row.ejs
@@ -1,7 +1,7 @@
 <div class="yahrzeit-row" id="row<%=num%>">
 <div class="row gy-1 gx-2 mb-3 align-items-center mt-1">
 <div class="col-auto"><%=num%>.</div>
-<div class="col-auto form-floating"><input class="form-control" type="text" name="n<%=num%>" id="n<%=num%>" value="<%= q['n'+num] || '' %>" placeholder="Name">
+<div class="col-auto form-floating"><input class="form-control" type="text" name="n<%=num%>" id="n<%=num%>" value="<%= q['n'+num] || '' %>" placeholder="Name" autocomplete="off" <%- locals.pmIgnore || '' %>>
 <label class="form-label" for="n<%=num%>">Name</label></div>
 <div class="col-auto form-floating"><select name="t<%=num%>" id="t<%=num%>" class="form-select">
  <option <%= (q['t'+num] === 'Yahrzeit') ? 'selected' : '' %>>Yahrzeit</option>
@@ -10,7 +10,7 @@
  <option <%= (q['t'+num] === 'Other') ? 'selected' : '' %>>Other</option>
 </select>
 <label class="form-label" for="t<%=num%>">Type</label></div>
-<div class="col-auto form-floating"><input class="form-control" type="text" inputmode="numeric" name="d<%=num%>" id="d<%=num%>" value="<%= q['d'+num] || '' %>" size="2" maxlength="2" max="31" min="1" pattern="\d*" placeholder="Day" title="Enter a day of the month between 1 and 31">
+<div class="col-auto form-floating"><input class="form-control" type="text" inputmode="numeric" name="d<%=num%>" id="d<%=num%>" value="<%= q['d'+num] || '' %>" size="2" maxlength="2" max="31" min="1" pattern="\d*" placeholder="Day" title="Enter a day of the month between 1 and 31" autocomplete="off">
 <label class="form-label" for="d<%=num%>">Day</label>
 <div class="invalid-feedback">Please enter a valid day of month.</div>
 </div>
@@ -29,7 +29,7 @@
  <option <%= q['m'+num] == 12 ? 'selected' : '' %> value="12">12-Dec</option>
 </select>
 <label class="form-label" for="m<%=num%>">Month</label></div>
-<div class="col-auto form-floating"><input class="form-control" type="text" inputmode="numeric" name="y<%=num%>" id="y<%=num%>" value="<%= q['y'+num] || '' %>" size="4" maxlength="4" pattern="\d*" placeholder="Year" title="Enter a year, for example 1970">
+<div class="col-auto form-floating"><input class="form-control" type="text" inputmode="numeric" name="y<%=num%>" id="y<%=num%>" value="<%= q['y'+num] || '' %>" size="4" maxlength="4" pattern="\d*" placeholder="Year" title="Enter a year, for example 1970" autocomplete="off" <%- locals.pmIgnore || '' %>>
 <label class="form-label" for="y<%=num%>">Year</label>
 <div class="invalid-feedback">Please enter a valid Gregorian year.</div>
 </div>

--- a/views/shabbat-browse.ejs
+++ b/views/shabbat-browse.ejs
@@ -18,7 +18,7 @@
   <input type="hidden" name="zip" id="zip">
   <label class="visually-hidden" for="city-typeahead">City</label>
   <div>
-    <input type="text" id="city-typeahead" class="form-control form-control-lg" placeholder="Search for city or ZIP code" enterkeyhint="search">
+    <input type="text" id="city-typeahead" class="form-control form-control-lg" placeholder="Search for city or ZIP code" enterkeyhint="search" autocomplete="off" <%- locals.pmIgnore || '' %>>
   </div>
 </form>
 </div><!-- .col-sm-10 -->

--- a/views/yahrzeit.ejs
+++ b/views/yahrzeit.ejs
@@ -177,7 +177,7 @@ data-count="<%=count%>" data-sprite-href="<%=spriteHref%>">
 <div class="row gx-2 mb-3 align-items-center">
   <label class="col-auto col-form-label" for="years">Number of years:</label>
   <div class="col-auto">
-    <input type="text" inputmode="numeric" name="years" value="<%= q.years %>" size="2" maxlength="2" class="form-control" id="years" max="99" min="1" pattern="\d*" title="Enter a number between 1 and 99">
+    <input type="text" inputmode="numeric" name="years" value="<%= q.years %>" size="2" maxlength="2" class="form-control" id="years" max="99" min="1" pattern="\d*" title="Enter a number between 1 and 99" autocomplete="off">
   </div>
 </div>
 </div><!-- .clearfix -->


### PR DESCRIPTION
## Summary

Adds `autocomplete="off"` to free-text inputs where browser autofill is unwanted, and layers the third-party password-manager opt-out attributes onto the fields those extensions are most likely to pop an autofill widget over (names and years).

Motivation: some fields — notably the `gy` year input on holiday/parsha detail pages — trigger a password-manager widget purely through the extensions' heuristics, even with no saved autofill data. `autocomplete="off"` alone does not stop that; the vendor opt-out attributes do.

## Approach

The opt-out attribute string is defined once as a shared `pmIgnore` template local in `src/app-www.js` and referenced in EJS as `<%- locals.pmIgnore || '' %>` so reusable partials degrade gracefully when rendered without it. The client-side `yahrzeitRow()` (used by the "Add another name" button and CSV import) mirrors the same attributes via a local `pmIgnore` const, kept in sync with the server local.

## Fields changed

**`autocomplete="off"` + password-manager opt-out** (`data-1p-ignore`, `data-bwignore`, `data-lpignore="true"`, `data-protonpass-ignore="true"`, `data-form-type="other"`):
- Yahrzeit **name** fields `n1/n2/n3` (server + dynamically-added rows)
- **Year** fields: converter `gy`/`hy`, holiday-detail `gy`, parsha-detail `gy`, custom-calendar `year`, Yahrzeit `y1/y2/y3`
- **City** typeaheads (added the opt-out alongside their existing `autocomplete="off"`)

**`autocomplete="off"` only** (date sub-fields, low widget temptation):
- Day fields `gd`, `hd`, Yahrzeit `d1/d2/d3`, and the "number of years" field

**Left at browser default** (autofill helpful or harmless): email signup fields, the site search box, 2-char minute/degree fields, and read-only copy-to-clipboard URL fields.

## Testing

- Full suite green: 465 passed, 8 skipped.
- Added throwaway render assertions confirming `gy`/`hy` emit the full opt-out, `gd`/`hd` emit `autocomplete` only, the `hebdate-picker` **partial** inherits the shared local, and no stray `undefined` leaks into markup.

## Note on a known duplication

The client-side `yahrzeitRow()` in `src/client-yahrzeit.js` is a hand-maintained copy of `views/partials/yahrzeit-row.ejs`. This PR updates both, but the duplication itself is deliberately left as-is here; a `<template>`/`cloneNode` refactor to remove it is proposed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HsbrshSu1rpwWVEsGLDwvL)_