### PR TITLE
Dedupe Yahrzeit row markup via a template clone

### DIFF
--- a/src/client-yahrzeit.js
+++ b/src/client-yahrzeit.js
@@ -10,60 +10,20 @@ function getCurrentCount() {
   return count;
 }
 
-const spriteHref = mainFormEl.dataset.spriteHref;
-// Keep in sync with the `pmIgnore` local in src/app-www.js: ask third-party
-// password managers to ignore these fields so they don't offer an autofill
-// widget. Paired with autocomplete="off" on names and years below.
-const pmIgnore = 'data-1p-ignore data-bwignore data-lpignore="true" '+
-  'data-protonpass-ignore="true" data-form-type="other"';
-function yahrzeitRow(n) {
-  return '<div class="row gy-1 gx-2 mb-3 align-items-center mt-1">'+
-  '<div class="col-auto">'+n+'.</div>' +
-  '<div class="col-auto form-floating">'+
-  '<input class="form-control" type="text" name="n'+n+'" id="n'+n+'" placeholder="Name" autocomplete="off" '+pmIgnore+'>'+
-  '<label class="form-label" for="n'+n+'">Name</label></div>'+
-  '<div class="col-auto form-floating"><select name="t'+n+'" id="t'+n+'" class="form-select">'+
-  '<option>Yahrzeit</option><option>Birthday</option><option>Anniversary</option><option>Other</option></select>'+
-  '<label class="form-label" for="t'+n+'">Type</label></div>'+
-  '<div class="col-auto form-floating">'+
-  '<input class="form-control" type="text" inputmode="numeric" name="d'+
-    n+'" id="d'+n+'" size="2" maxlength="2" max="31" min="1" pattern="\\d*" placeholder="Day" autocomplete="off">'+
-  '<label class="form-label" for="d'+n+'">Day</label>'+
-  '<div class="invalid-feedback">Please enter a valid day of month.</div>'+
-  '</div>'+
-  '<div class="col-auto form-floating"><select name="m'+n+'" id="m'+n+'" class="form-select">'+
-  '<option value="1">01-Jan</option><option value="2">02-Feb</option><option value="3">03-Mar</option>'+
-  '<option value="4">04-Apr</option><option value="5">05-May</option><option value="6">06-Jun</option>'+
-  '<option value="7">07-Jul</option><option value="8">08-Aug</option><option value="9">09-Sep</option>'+
-  '<option value="10">10-Oct</option><option value="11">11-Nov</option><option value="12">12-Dec</option>'+
-  '</select>'+
-  '<label class="form-label" for="m'+n+'">Month</label></div>'+
-  '<div class="col-auto form-floating">'+
-  '<input class="form-control" type="text" inputmode="numeric" name="y'+
-    n+'" id="y'+n+'" size="4" maxlength="4" pattern="\\d*" placeholder="Year" autocomplete="off" '+pmIgnore+'>'+
-  '<label class="form-label" for="y'+n+'">Year</label>'+
-  '<div class="invalid-feedback">Please enter a valid Gregorian year.</div>'+
-  '</div>'+
-  '<div class="col-auto m-2"><div class="form-check">'+
-  '<input class="form-check-input" type="radio" name="s'+n+'" id="s'+n+'-0" checked="" value="off">'+
-  '<label class="form-check-label small" for="s'+n+'-0">Before sunset</label></div>'+
-  '<div class="form-check">'+
-  '<input class="form-check-input" type="radio" name="s'+n+'" id="s'+n+'-1" value="on">'+
-  '<label class="form-check-label small" for="s'+n+'-1">After sunset</label></div>'+
-  '</div>' +
-  '<div class="col-auto ms-2">' +
-  '<button type="button" class="btn btn-sm btn-outline-danger del" id="del-'+n+'">'+
-  '<svg class="icon"><use href="' + spriteHref + '#bi-trash"></use></svg>'+
-  ' Delete</button></div>'+
-  '</div>';
-}
+// The blank-row markup lives in a single place: views/partials/yahrzeit-row.ejs.
+// The server renders it once into <template id="yahrzeit-row-tmpl"> with the
+// literal token __IDX__ standing in for the row number (see views/yahrzeit.ejs).
+// To add a row we take that markup and swap __IDX__ for the new row number.
+// A token replace (rather than cloning and walking attributes) is used because
+// the index appears in both attributes and a text node (the "N." row label),
+// and the ids are irregular (del-N, sN-0), so one string pass is simplest.
+const rowTmpl = document.getElementById('yahrzeit-row-tmpl');
 
 function addNewRow() {
   const n = ++count;
-  const newNode = document.createElement('div');
-  newNode.className = 'yahrzeit-row';
-  newNode.id = 'row' + n;
-  newNode.innerHTML = yahrzeitRow(n);
+  const holder = document.createElement('div');
+  holder.innerHTML = rowTmpl.innerHTML.replace(/__IDX__/g, n);
+  const newNode = holder.firstElementChild;
   const parentDiv = document.getElementById('rows');
   parentDiv.insertBefore(newNode, null);
   const delBtn = document.getElementById('del-'+n);

--- a/src/client-yahrzeit.js
+++ b/src/client-yahrzeit.js
@@ -22,7 +22,7 @@ const rowTmpl = document.getElementById('yahrzeit-row-tmpl');
 function addNewRow() {
   const n = ++count;
   const holder = document.createElement('div');
-  holder.innerHTML = rowTmpl.innerHTML.replace(/__IDX__/g, n);
+  holder.innerHTML = rowTmpl.innerHTML.replaceAll('__IDX__', n);
   const newNode = holder.firstElementChild;
   const parentDiv = document.getElementById('rows');
   parentDiv.insertBefore(newNode, null);

--- a/views/yahrzeit.ejs
+++ b/views/yahrzeit.ejs
@@ -135,7 +135,7 @@ Use the <span class="btn btn-sm btn-outline-success disabled" style="opacity: 1;
 Add another name</span> button at the bottom of the page to add
 additional names. Use 4-digit years (e.g. 2015 instead of 15).</p>
 <form id="f3" class="d-print-none needs-validation" method="post" action="/yahrzeit"
-data-count="<%=count%>" data-sprite-href="<%=spriteHref%>">
+data-count="<%=count%>">
 <div id="rows">
 <% for (let num = 1; num <= count; num++) { -%>
 <% if (typeof q['t'+num] === 'string') { -%>
@@ -147,6 +147,10 @@ data-count="<%=count%>" data-sprite-href="<%=spriteHref%>">
 <%- await include('partials/yahrzeit-row.ejs', {num: 1}) -%>
 <% } -%>
 </div><!-- #rows -->
+<%# Blank row cloned by client-yahrzeit.js when adding a name or importing CSV.
+    Rendered once from the same partial as the rows above, with __IDX__ as a
+    placeholder index that the client replaces with the new row number. -%>
+<template id="yahrzeit-row-tmpl"><%- await include('partials/yahrzeit-row.ejs', {num: '__IDX__'}) %></template>
 <div class="clearfix">
 <p class="text-end float-sm-end">
  <button type="button" class="btn btn-success mt-2" id="newrow">


### PR DESCRIPTION
## Summary

Removes the long-standing duplication between `views/partials/yahrzeit-row.ejs` (server-rendered rows) and the `yahrzeitRow()` string builder in `src/client-yahrzeit.js` (rows added by the "Add another name" button and CSV import). The two were hand-maintained copies that drifted independently — most recently the autofill / password-manager opt-out attributes had to be added in both places.

Follow-up to #87, which is the change that motivated this cleanup.

## Approach

The server now renders the existing partial **once** into an inert `<template id="yahrzeit-row-tmpl">`, passing the literal token `__IDX__` as the row index. To add a row, the client takes that markup and replaces `__IDX__` with the new row number. The EJS partial is the single source of truth for the row markup; the client script owns only the numbering.

```
views/partials/yahrzeit-row.ejs   ──rendered with num──▶  server rows (real values)
                │
                └──rendered with num='__IDX__'──▶  <template>  ──cloned + renumbered──▶  client rows
```

`<template>` is a native HTML element whose contents are parsed but inert (not rendered, not submitted, invisible to `getElementById`) until cloned into the live document — so the placeholder ids inside it never collide with the real rows.

A token replace is used rather than `cloneNode` + attribute rewriting because the index appears in a **text node** (the "N." row label) as well as in **irregular ids** (`del-N`, `sN-0`), which an attribute walk would miss; one string pass handles both uniformly.

Also drops the now-unused `data-sprite-href` form attribute and the `spriteHref` / `pmIgnore` constants from the client script — the trash icon and opt-out attributes are now pre-rendered in the template.

## Net effect

`src/client-yahrzeit.js`: −52 / +16 lines (the ~40-line HTML string builder is gone).

## Testing

- Full server test suite green: 465 passed, 8 skipped.
- Added server-side render assertions (throwaway) confirming the template renders with `__IDX__` tokens and the correct opt-out attributes, and that `__IDX__` → N substitution yields well-formed, uniquely-numbered rows.
- **Real-browser test** (throwaway script using the already-present `puppeteer` dep + pre-installed Chromium — no `package.json` change): loads `/yahrzeit/new`, clicks "Add another name" twice, and verifies 3 uniquely-numbered rows, the `N.` text label, blank/default field state, the name/year snub attributes vs. day (autocomplete only), a working Delete button, no leftover `__IDX__` in the live DOM, and zero page JS errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HsbrshSu1rpwWVEsGLDwvL)_