### PR TITLE
Show Haftarot of Admonition/Consolation on parsha detail pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@hebcal/hdate": "^0.22.5",
     "@hebcal/icalendar": "^6.3.8",
     "@hebcal/learning": "^6.9.5",
-    "@hebcal/leyning": "^9.5.5",
+    "@hebcal/leyning": "^9.6.0",
     "@hebcal/locales": "^6.5.1",
     "@hebcal/rest-api": "^6.5.1",
     "@hebcal/triennial": "^6.3.0",

--- a/src/parshaCommon.js
+++ b/src/parshaCommon.js
@@ -165,13 +165,16 @@ export function lookupParshaMeta(parshaName) {
     parsha.p1anchor = makeAnchor(p1);
     parsha.p2anchor = makeAnchor(p2);
     const haftKey = p1 === 'Nitzavim' ? p1 : p2;
-    parsha.haft = lookupParsha(haftKey).haft;
+    const haftMeta = lookupParsha(haftKey);
+    parsha.haft = haftMeta.haft;
+    parsha.haftTheme = haftMeta.haftTheme;
     const p1meta = lookupParsha(p1);
     parsha.p1verses = parshaVerses(p1meta);
   } else {
     parsha.ordinal = Locale.ordinal(parsha.num, 'en');
   }
   parsha.haftara = makeSummaryFromParts(parsha.haft);
+  parsha.haftThemeStr = formatHaftarahTheme(parsha.haftTheme);
   const chapVerse = parsha.fullkriyah['1'][0];
   const [chapter, verse] = chapVerse.split(':');
   const book = parsha.book;
@@ -185,6 +188,35 @@ export function lookupParshaMeta(parshaName) {
 function parshaVerses(parshaMeta) {
   const fk = parshaMeta.fullkriyah;
   return fk['1'][0] + '-' + fk['7'][1];
+}
+
+const ORDINAL_WORDS = [
+  null, 'First', 'Second', 'Third', 'Fourth', 'Fifth', 'Sixth', 'Seventh',
+];
+
+/**
+ * Formats a HaftTheme (admonition/consolation) as a human-readable string
+ * like `"Fifth Haftarah of Consolation"`. The rare `consolation: "3,5"` case
+ * (Parashat Re'eh coincides with Rosh Chodesh, displacing the 3rd Haftarah of
+ * Consolation onto Ki Teitzei alongside the 5th) is rendered as
+ * `"Third and Fifth Haftarah of Consolation"`.
+ * @param {{admonition?: number, consolation?: number|string}} [theme]
+ * @return {string|undefined}
+ */
+export function formatHaftarahTheme(theme) {
+  if (!theme) {
+    return undefined;
+  }
+  if (typeof theme.admonition === 'number') {
+    return `${ORDINAL_WORDS[theme.admonition]} Haftarah of Admonition`;
+  }
+  if (typeof theme.consolation !== 'undefined') {
+    const ordinals = String(theme.consolation).split(',')
+        .map((num) => ORDINAL_WORDS[Number(num)])
+        .join(' and ');
+    return `${ordinals} Haftarah of Consolation`;
+  }
+  return undefined;
 }
 
 /**

--- a/src/sedrot.js
+++ b/src/sedrot.js
@@ -11,7 +11,8 @@ import {makeGregDate, simchatTorahDate, yearIsOutsideGregRange} from './dateUtil
 import {sedrot, doubled, addLinksToLeyning, makeLeyningHtmlFromParts,
   drash,
   VEZOT_HABERAKHAH,
-  lookupParshaMeta, lookupParshaAlias, parshaNum} from './parshaCommon.js';
+  lookupParshaMeta, lookupParshaAlias, parshaNum,
+  formatHaftarahTheme} from './parshaCommon.js';
 import {getParshaMultiYearItems} from './parshaMultiYearItems.js';
 import dayjs from 'dayjs';
 
@@ -187,6 +188,8 @@ function makeReading(date, parshaEv, il, parsha) {
     }
   }
   reading.haftaraHtml = makeLeyningHtmlFromParts(reading.haft);
+  const haftTheme = (reading.admonition || reading.consolation) ? reading : parsha.haftTheme;
+  reading.haftThemeStr = formatHaftarahTheme(haftTheme);
   if (reading.seph) {
     reading.sephardicHtml = makeLeyningHtmlFromParts(reading.seph);
   }

--- a/test/misc.test.js
+++ b/test/misc.test.js
@@ -134,6 +134,39 @@ describe('Leyning Routes', () => {
     expect(response.status).toBe(405);
     expect(response.type).toContain('html');
   });
+
+  it('should include admonition in JSON for a Haftarah of Admonition', async () => {
+    // Parashat Devarim 2026-07-18 is the 3rd Haftarah of Admonition
+    const response = await request(server)
+        .get('/leyning?cfg=json&date=2026-07-18');
+    expect(response.status).toBe(200);
+    expect(response.type).toContain('json');
+    const item = response.body.items[0];
+    expect(item.admonition).toBe(3);
+    expect(item.consolation).toBeUndefined();
+  });
+
+  it('should include consolation in JSON for a Haftarah of Consolation', async () => {
+    // Parashat Vaetchanan 2026-07-25 is the 1st Haftarah of Consolation
+    const response = await request(server)
+        .get('/leyning?cfg=json&date=2026-07-25');
+    expect(response.status).toBe(200);
+    expect(response.type).toContain('json');
+    const item = response.body.items[0];
+    expect(item.consolation).toBe(1);
+    expect(item.admonition).toBeUndefined();
+  });
+
+  it('should include the special "3,5" consolation value in JSON for Ki Teitzei', async () => {
+    // In 2029, Parashat Re'eh coincides with Shabbat Rosh Chodesh Elul, displacing
+    // the 3rd Haftarah of Consolation onto Ki Teitzei alongside the usual 5th.
+    const response = await request(server)
+        .get('/leyning?cfg=json&date=2029-08-25');
+    expect(response.status).toBe(200);
+    expect(response.type).toContain('json');
+    const item = response.body.items[0];
+    expect(item.consolation).toBe('3,5');
+  });
 });
 
 describe('Delete Cookie Route', () => {

--- a/test/sedrot.test.js
+++ b/test/sedrot.test.js
@@ -319,6 +319,67 @@ describe('Sedrot with Dates - Content Verification', () => {
   });
 });
 
+describe('Sedrot Haftarot of Admonition and Consolation', () => {
+  it('should show ordinal Haftarah of Admonition for Devarim', async () => {
+    const response = await request(server)
+        .get('/sedrot/devarim-20260718');
+    expect(response.status).toBe(200);
+    expect(response.text).toContain('Third Haftarah of Admonition');
+  });
+
+  it('should show ordinal Haftarah of Consolation for Vaetchanan', async () => {
+    const response = await request(server)
+        .get('/sedrot/vaetchanan-20260725');
+    expect(response.status).toBe(200);
+    expect(response.text).toContain('First Haftarah of Consolation');
+  });
+
+  it('should show Second Haftarah of Admonition for combined Matot-Masei (dated)', async () => {
+    const response = await request(server)
+        .get('/sedrot/matot-masei-20260711');
+    expect(response.status).toBe(200);
+    expect(response.text).toContain('Second Haftarah of Admonition');
+  });
+
+  it('should show Second Haftarah of Admonition for combined Matot-Masei (undated)', async () => {
+    const response = await request(server)
+        .get('/sedrot/matot-masei');
+    expect(response.status).toBe(200);
+    expect(response.text).toContain('Second Haftarah of Admonition');
+  });
+
+  it('should show Seventh Haftarah of Consolation for combined Nitzavim-Vayeilech (dated)', async () => {
+    const response = await request(server)
+        .get('/sedrot/nitzavim-vayeilech-20260905');
+    expect(response.status).toBe(200);
+    expect(response.text).toContain('Seventh Haftarah of Consolation');
+  });
+
+  it('should show Seventh Haftarah of Consolation for combined Nitzavim-Vayeilech (undated)', async () => {
+    const response = await request(server)
+        .get('/sedrot/nitzavim-vayeilech');
+    expect(response.status).toBe(200);
+    expect(response.text).toContain('Seventh Haftarah of Consolation');
+  });
+
+  it('should not show a Haftarah theme for a parsha unrelated to Tisha B\'Av', async () => {
+    const response = await request(server)
+        .get('/sedrot/bereshit-20241026');
+    expect(response.status).toBe(200);
+    expect(response.text).not.toContain('Haftarah of Admonition');
+    expect(response.text).not.toContain('Haftarah of Consolation');
+  });
+
+  it('should render "Third and Fifth" for the rare Ki Teitzei consolation 3,5 special case', async () => {
+    // In 2029, Parashat Re'eh coincides with Shabbat Rosh Chodesh Elul, displacing
+    // the 3rd Haftarah of Consolation onto Ki Teitzei alongside the usual 5th.
+    const response = await request(server)
+        .get('/sedrot/ki-teitzei-20290825');
+    expect(response.status).toBe(200);
+    expect(response.text).toContain('Third and Fifth Haftarah of Consolation');
+  });
+});
+
 describe('Sedrot Hebrew Year Pages', () => {
   it('should return 200 for Hebrew year 5785', async () => {
     const response = await request(server)

--- a/views/partials/haftara.ejs
+++ b/views/partials/haftara.ejs
@@ -3,6 +3,7 @@
 <%- reading.haftaraHtml %>
 <%- await include('numverses.ejs', {v: reading.haftaraNumV}) -%>
 <% if (reading?.reason?.haftara) { %><br><span class="text-success ps-1 small">*<%= reading.reason.haftara %> <%= date ? '' : 'on ' + d.format('D MMMM YYYY') %></span><% } %>
+<% if (reading.haftThemeStr) { %><br><small class="text-body-secondary"><%= reading.haftThemeStr %></small><% } %>
 </p>
 <% } // reading.haftara %>
 <% if (reading.sephardic) { %>


### PR DESCRIPTION
Bumps @hebcal/leyning to 9.6.0, which exposes the admonition/consolation
theme (the three Haftarot of Admonition before Tisha B'Av and the seven
of Consolation after) on leyning results. Renders the ordinal, e.g.
"Fifth Haftarah of Consolation", in small muted text below the Haftarah
on /sedrot pages, including the rare "Third and Fifth" case when Ki
Teitzei absorbs the displaced 3rd Haftarah of Consolation.