### PR TITLE
Extract Haftarah theme formatting to shared module

### DIFF
--- a/src/haftarahTheme.js
+++ b/src/haftarahTheme.js
@@ -1,0 +1,28 @@
+const ORDINAL_WORDS = [
+  null, 'First', 'Second', 'Third', 'Fourth', 'Fifth', 'Sixth', 'Seventh',
+];
+
+/**
+ * Formats a HaftTheme (admonition/consolation) as a human-readable string
+ * like `"Fifth Haftarah of Consolation"`. The rare `consolation: "3,5"` case
+ * (Parashat Re'eh coincides with Rosh Chodesh, displacing the 3rd Haftarah of
+ * Consolation onto Ki Teitzei alongside the 5th) is rendered as
+ * `"Third and Fifth Haftarah of Consolation"`.
+ * @param {{admonition?: number, consolation?: number|string}} [theme]
+ * @return {string|undefined}
+ */
+export function formatHaftarahTheme(theme) {
+  if (!theme) {
+    return undefined;
+  }
+  if (typeof theme.admonition === 'number') {
+    return `${ORDINAL_WORDS[theme.admonition]} Haftarah of Admonition`;
+  }
+  if (typeof theme.consolation !== 'undefined') {
+    const ordinals = String(theme.consolation).split(',')
+        .map((num) => ORDINAL_WORDS[Number(num)])
+        .join(' and ');
+    return `${ordinals} Haftarah of Consolation`;
+  }
+  return undefined;
+}

--- a/src/parshaCommon.js
+++ b/src/parshaCommon.js
@@ -2,6 +2,7 @@ import {HebrewCalendar, Locale, parshiot, flags} from '@hebcal/core';
 import {formatAliyahShort, lookupParsha, makeSummaryFromParts} from '@hebcal/leyning';
 import {makeAnchor} from '@hebcal/rest-api';
 import {langNames} from './lang.js';
+import {formatHaftarahTheme} from './haftarahTheme.js';
 import {transliterate} from 'transliteration';
 import {distance, closest} from 'fastest-levenshtein';
 import {readJSON} from './readJSON.js';
@@ -188,35 +189,6 @@ export function lookupParshaMeta(parshaName) {
 function parshaVerses(parshaMeta) {
   const fk = parshaMeta.fullkriyah;
   return fk['1'][0] + '-' + fk['7'][1];
-}
-
-const ORDINAL_WORDS = [
-  null, 'First', 'Second', 'Third', 'Fourth', 'Fifth', 'Sixth', 'Seventh',
-];
-
-/**
- * Formats a HaftTheme (admonition/consolation) as a human-readable string
- * like `"Fifth Haftarah of Consolation"`. The rare `consolation: "3,5"` case
- * (Parashat Re'eh coincides with Rosh Chodesh, displacing the 3rd Haftarah of
- * Consolation onto Ki Teitzei alongside the 5th) is rendered as
- * `"Third and Fifth Haftarah of Consolation"`.
- * @param {{admonition?: number, consolation?: number|string}} [theme]
- * @return {string|undefined}
- */
-export function formatHaftarahTheme(theme) {
-  if (!theme) {
-    return undefined;
-  }
-  if (typeof theme.admonition === 'number') {
-    return `${ORDINAL_WORDS[theme.admonition]} Haftarah of Admonition`;
-  }
-  if (typeof theme.consolation !== 'undefined') {
-    const ordinals = String(theme.consolation).split(',')
-        .map((num) => ORDINAL_WORDS[Number(num)])
-        .join(' and ');
-    return `${ordinals} Haftarah of Consolation`;
-  }
-  return undefined;
 }
 
 /**

--- a/src/sedrot.js
+++ b/src/sedrot.js
@@ -11,8 +11,8 @@ import {makeGregDate, simchatTorahDate, yearIsOutsideGregRange} from './dateUtil
 import {sedrot, doubled, addLinksToLeyning, makeLeyningHtmlFromParts,
   drash,
   VEZOT_HABERAKHAH,
-  lookupParshaMeta, lookupParshaAlias, parshaNum,
-  formatHaftarahTheme} from './parshaCommon.js';
+  lookupParshaMeta, lookupParshaAlias, parshaNum} from './parshaCommon.js';
+import {formatHaftarahTheme} from './haftarahTheme.js';
 import {getParshaMultiYearItems} from './parshaMultiYearItems.js';
 import dayjs from 'dayjs';
 

--- a/src/torahMemo.js
+++ b/src/torahMemo.js
@@ -1,6 +1,7 @@
 import {flags} from '@hebcal/core';
 import {getLeyningForParshaHaShavua, getLeyningForHoliday} from '@hebcal/leyning';
 import {LEARNING_MASK, getHolidayDescription} from '@hebcal/rest-api';
+import {formatHaftarahTheme} from './haftarahTheme.js';
 
 /**
  * Bitmask of event types that never have a Torah reading of their own
@@ -39,6 +40,11 @@ export function makeTorahMemoText(ev, il) {
       memo += 'Haftarah: ' + reading.haftara;
       if (reading.reason?.haftara) {
         memo += ' | ' + reading.reason.haftara;
+      }
+      // one of the Haftarot of Admonition or Consolation around Tish'a B'Av
+      const haftThemeStr = formatHaftarahTheme(reading);
+      if (haftThemeStr) {
+        memo += ' | ' + haftThemeStr;
       }
     }
   }

--- a/test/torahMemo.test.js
+++ b/test/torahMemo.test.js
@@ -18,6 +18,42 @@ describe('makeTorahMemoText', () => {
     ]);
   });
 
+  it('includes the Haftarah of Admonition or Consolation', () => {
+    const memoForDate = (y, m, d) => {
+      const events = HebrewCalendar.calendar({
+        noHolidays: true,
+        sedrot: true,
+        start: new Date(y, m, d),
+        end: new Date(y, m, d),
+      });
+      return makeTorahMemoText(events[0], false).split('\n');
+    };
+    // Parashat Devarim: 3rd Haftarah of Admonition
+    expect(memoForDate(2025, 7, 2)).toEqual([
+      'Torah: Deuteronomy 1:1-3:22',
+      'Haftarah: Isaiah 1:1-27 | Third Haftarah of Admonition',
+    ]);
+    // Parashat Vaetchanan: 1st Haftarah of Consolation
+    expect(memoForDate(2025, 7, 9)).toEqual([
+      'Torah: Deuteronomy 3:23-7:11',
+      'Haftarah: Isaiah 40:1-26 | First Haftarah of Consolation',
+    ]);
+    // Parashat Matot-Masei: theme appears after the reason for a special Haftarah
+    expect(memoForDate(2025, 6, 26)).toEqual([
+      'Torah: Numbers 30:2-36:13, 28:9-15',
+      'Haftarah: Jeremiah 2:4-28, 3:4 | Matot-Masei on Shabbat Rosh Chodesh' +
+        ' | Second Haftarah of Admonition',
+      'Haftarah for Sephardim: Jeremiah 2:4-28, 4:1-2; Isaiah 66:1, 66:23',
+    ]);
+    // Parashat Ki Teitzei: the displaced 3rd Haftarah of Consolation
+    // chanted along with the 5th
+    expect(memoForDate(2022, 8, 10)).toEqual([
+      'Torah: Deuteronomy 21:10-25:19',
+      'Haftarah: Isaiah 54:1-10, 54:11-55:5 | Ki Teitzei with 3rd Haftarah of' +
+        ' Consolation | Third and Fifth Haftarah of Consolation',
+    ]);
+  });
+
   it('ignores user events but not holidays', () => {
     const hd = new HDate(new Date(2021, 1, 13));
     const userEvent = new Event(hd, 'User Event', flags.USER_EVENT);


### PR DESCRIPTION
## Summary
Refactors the `formatHaftarahTheme()` function into a dedicated module to enable reuse across multiple features, and adds Haftarah theme display to Torah memo text.

## Changes
- **New module** `src/haftarahTheme.js`: Extracted `formatHaftarahTheme()` function and `ORDINAL_WORDS` constant from `parshaCommon.js` for shared use
- **Updated imports**: `src/parshaCommon.js` and `src/sedrot.js` now import `formatHaftarahTheme` from the new module
- **Enhanced Torah memos**: `src/torahMemo.js` now displays Haftarah themes (e.g., "Third Haftarah of Admonition", "First Haftarah of Consolation") when present in the reading data
- **Test coverage**: Added comprehensive test cases in `test/torahMemo.test.js` covering:
  - Parashat Devarim (3rd Haftarah of Admonition)
  - Parashat Vaetchanan (1st Haftarah of Consolation)
  - Parashat Matot-Masei (theme after special Haftarah reason)
  - Parashat Ki Teitzei (displaced 3rd Haftarah of Consolation with 5th)

## Implementation Details
The Haftarah theme is appended to the memo text with a pipe separator, appearing after any special Haftarah reason (e.g., "Rosh Chodesh"). This handles the rare case where multiple Haftarot are combined (e.g., "Third and Fifth Haftarah of Consolation").

https://claude.ai/code/session_01VfZ8DPBYWTK8AbvHUraEws