### PR TITLE
Fix drifted EJS comment markers; make checkbox group a fieldset

### DIFF
--- a/views/converter.ejs
+++ b/views/converter.ejs
@@ -84,7 +84,7 @@ const isPast = hy < todayHebYear;
 <% } -%>
 <div id="ctoday" class="d-flex justify-content-center d-print-none">
 </div>
-</div><!-- .clearfix -->
+</div><!-- .overflow-auto -->
 <div id="converter-form" class="d-print-none mt-4">
 <div class="row">
 <div class="col-md">

--- a/views/hebcal-results.ejs
+++ b/views/hebcal-results.ejs
@@ -130,7 +130,7 @@ accurate.
 <a class="btn btn-secondary btn-sm mb-1" href="<%= url.settings %>" data-bs-toggle="offcanvas" data-bs-target="#offcanvas-settings" aria-controls="offcanvas-settings" title="Change calendar options">
   <svg class="icon align-top"><use href="<%=spriteHref%>#bi-gear-fill"></use></svg>
   Settings</a>
-</div><!-- .btn-toolbar -->
+</div><!-- .d-print-none -->
 </div><!-- .col-sm-8 -->
 <div class="col-sm-4 d-print-none">
 <div class="d-flex justify-content-center d-print-none">

--- a/views/holiday-main-index.ejs
+++ b/views/holiday-main-index.ejs
@@ -45,7 +45,7 @@ data-ad-slot="1140358973"></ins>
 <script nonce="<%=nonce%>">
 (adsbygoogle = window.adsbygoogle || []).push({});
 </script>
-</div><!-- .d-flex -->
+</div><!-- .d-print-none -->
 </div><!-- .col-sm-4 -->
 </div><!-- .row -->
 <div class="row mt-2 d-print-none">

--- a/views/partials/hebcal-form.ejs
+++ b/views/partials/hebcal-form.ejs
@@ -74,7 +74,7 @@ if (typeof year !== 'string' || year.length === 0) {
 <input class="form-check-input" type="checkbox" name="s" value="on" <%= q.s === 'on' ? 'checked' : '' %> id="s">
 <label class="form-check-label" for="s">Weekly Torah portion on Saturdays</label>
 </div></fieldset>
-</div><!-- .col-sm-6 -->
+</div><!-- .col -->
 <div class="col-sm-auto mb-2">
 <fieldset class="mb-2">
 <div class="form-check mb-1">
@@ -122,7 +122,7 @@ if (typeof year !== 'string' || year.length === 0) {
 </div>
 <details <%= Object.keys(q).filter((key) => q[key] === 'on' && dailyLearningOpts[key]).length > 0 ? 'open' : ''%> class="mb-3">
 <summary class="fw-bold mb-2">Daily Learning</summary>
-<div>
+<fieldset>
 <% for (const key of Object.keys(dailyLearningOpts)) { %>
 <div class="form-check mb-2">
 <input class="form-check-input" type="checkbox" name="<%=key%>" value="on" <%= q[key] === 'on' ? 'checked' : '' %> id="<%=key%>">
@@ -131,7 +131,7 @@ if (typeof year !== 'string' || year.length === 0) {
  data-bs-placement="top"><svg class="icon icon-sm mt-n1"><use href="<%=spriteHref%>#bi-info-circle-fill"></use></svg></span><% } %>
 </div>
 <% } %>
-</div><!-- .collapse -->
+</fieldset>
 </details>
 <details <%= q['city-typeahead'] ? 'open' : ''%> class="mb-2">
 <summary class="fw-bold mb-3">Candle-lighting &amp; Fast times</summary>
@@ -194,7 +194,7 @@ if (typeof year !== 'string' || year.length === 0) {
   </div>
 </fieldset>
 </details>
-</div><!-- .col-sm-6 -->
+</div><!-- .col -->
 </div><!-- .row -->
 <button type="submit" class="btn btn-primary">Create Calendar</button>
 </form>

--- a/views/shabbat-browse.ejs
+++ b/views/shabbat-browse.ejs
@@ -8,7 +8,7 @@
 
 <h1>Shabbat Candle-lighting Times</h1>
 <p class="lead">Candle-lighting and Havdalah times. Weekly Torah portion.</p>
-</div><!-- .col-sm-12 -->
+</div><!-- .col -->
 </div><!-- .row -->
 <div class="row">
 <div class="col-sm-10 col-sm-offset-1">

--- a/views/yahrzeit.ejs
+++ b/views/yahrzeit.ejs
@@ -143,7 +143,7 @@ data-count="<%=count%>">
 <% } -%>
 <% } %>
 <% if (count === 1 && typeof q.t1 !== 'string') { -%>
-<!-- empty form -->
+<%# empty form %>
 <%- await include('partials/yahrzeit-row.ejs', {num: 1}) -%>
 <% } -%>
 </div><!-- #rows -->


### PR DESCRIPTION
## Summary

Cleanup pass on the `</div><!-- .foo -->` markers in the EJS templates, plus one
small semantic improvement.

I audited all 319 markers with a script that strips EJS tags, walks a div stack,
and compares each marker against the class/id of the element it actually closes.
Result: **0 mismatches** in templates without EJS control flow, and 7 drifted
markers in templates with it.

## Convention adopted

For the ambiguous cases, two rules:

- **`.col`** closes a column regardless of its exact Bootstrap class
  (`col-auto`, `col-sm-6`, `col-md-4` …). The marker says "this is a column,"
  not "this element has literally this class."
- **`.d-print-none`** flags a block that is not rendered when printing.

## Markers fixed

| File | Was | Now |
|---|---|---|
| `converter.ejs` | `.clearfix` | `.overflow-auto` |
| `hebcal-results.ejs` | `.btn-toolbar` | `.d-print-none` |
| `holiday-main-index.ejs` | `.d-flex` | `.d-print-none` |
| `partials/hebcal-form.ejs` ×2 | `.col-sm-6` | `.col` |
| `shabbat-browse.ejs` | `.col-sm-12` | `.col` |

Only line 48 of `holiday-main-index.ejs` changed — line 36 closes a genuine
`.d-flex` and was left alone.

## `<div>` → `<fieldset>`

The `.collapse` marker in `hebcal-form.ejs` was left over from a Bootstrap
collapse widget that has since been rewritten as a native `<details>`/`<summary>`.
The classless `<div>` it closed groups the Daily Learning checkboxes — which is
exactly what `<fieldset>` is for. Switched to `<fieldset>` and dropped the marker
entirely, since `</fieldset>` is self-describing.

**This does not change rendering.** Bootstrap's Reboot resets
`fieldset { min-width: 0; padding: 0; margin: 0; border: 0 }`, which I confirmed
is present in the compiled `style-5.3.8k.css` after a full `npm run build` (it
survives PurgeCSS). The same file already uses a `<fieldset class="mt-2">` a few
lines below, so the pattern is proven here. Verified the rendered page still
returns 200 with all 19 checkboxes inside the fieldset and balanced div tags.

## Developer-facing comment

`yahrzeit.ejs` had `<!-- empty form -->` — a note to developers shipped to every
visitor. Rewrote as `<%# empty form %>` so it stays server-side.

Worth noting what I did **not** do: the ~318 remaining structural markers stay as
HTML comments. They cost ~99 bytes per page after brotli (under 1%), and they are
genuinely useful when reading page source in a browser. Only prose notes aimed at
developers belong in `<%# %>`.

## Testing

`npm run build` succeeds, `npm run lint` exits 0, `npm test` is **572 passed,
8 skipped**. Re-running the marker audit afterwards shows every remaining flag is
a `.col` closing a column — i.e. the convention above, working as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)