### PR TITLE
Call the bare @hebcal/core functions instead of the HebrewCalendar statics

### DIFF
--- a/src/converter.js
+++ b/src/converter.js
@@ -1,5 +1,5 @@
-import {HDate, HebrewCalendar, Event, ParshaEvent, Locale, months,
-  OmerEvent, gematriya, greg} from '@hebcal/core';
+import {HDate, HebrewCalendar, Event, ParshaEvent, Locale, months, OmerEvent, gematriya,
+  greg, getHolidaysOnDate, getSedra} from '@hebcal/core';
 import dayjs from 'dayjs';
 import {checkFreshETag} from './etag.js';
 import {httpRedirect, hebrewFontPreload, jsonpBody} from './common.js';
@@ -423,7 +423,7 @@ function getEvents(hdate, il) {
 function getParshaEvents(hdate, il) {
   const saturday = hdate.onOrAfter(6);
   const hy = saturday.getFullYear();
-  const sedra = HebrewCalendar.getSedra(hy, il);
+  const sedra = getSedra(hy, il);
   const parsha = sedra.lookup(saturday);
   if (!parsha.chag) {
     const pe = new ParshaEvent(parsha);
@@ -449,7 +449,7 @@ function getParshaEvents(hdate, il) {
       });
       events = events.concat(pe);
     } else {
-      const satHolidays = HebrewCalendar.getHolidaysOnDate(saturday, il) || [];
+      const satHolidays = getHolidaysOnDate(saturday, il) || [];
       for (const ev of satHolidays) {
         const pe = new PseudoParshaEvent(ev);
         events = events.concat(pe);

--- a/src/dailyLearning.js
+++ b/src/dailyLearning.js
@@ -6,7 +6,7 @@ import {localeMap} from './lang.js';
 import {queryLongDescr, dailyLearningConfig} from './urlArgs.js';
 import {isoDateStringToDate} from './dateUtil.js';
 import {basename} from 'node:path';
-import {HDate, HebrewCalendar, months, OmerEvent, Locale} from '@hebcal/core';
+import {HDate, HebrewCalendar, months, OmerEvent, Locale, getHolidaysOnDate} from '@hebcal/core';
 import {getLeyningOnDate, makeLeyningParts} from '@hebcal/leyning';
 import {makeLeyningHtmlFromParts} from './parshaCommon.js';
 import {makeAnchor} from '@hebcal/rest-api';
@@ -56,7 +56,7 @@ export function dailyLearningApp(ctx) {
     dailyLearning: dlOpts,
   });
 
-  const holidays = HebrewCalendar.getHolidaysOnDate(hd, il) || [];
+  const holidays = getHolidaysOnDate(hd, il) || [];
   const mm = hd.getMonth();
   if (mm === months.NISAN || mm === months.IYYAR || mm === months.SIVAN) {
     const beginOmer = HDate.hebrew2abs(hd.getFullYear(), months.NISAN, 16);

--- a/src/etag.js
+++ b/src/etag.js
@@ -1,5 +1,5 @@
 import {murmur128Sync} from 'murmurhash3';
-import {HebrewCalendar} from '@hebcal/core';
+import {version as coreVersion} from '@hebcal/core';
 import {pkg} from './pkg.js';
 
 function murmur128SyncBase64(str) {
@@ -19,7 +19,7 @@ function murmur128SyncBase64(str) {
  */
 
 export function makeETag(ctx, options, attrs) {
-  const vers = {core: HebrewCalendar.version(), web: pkg.version};
+  const vers = {core: coreVersion, web: pkg.version};
   const etagObj = {...vers, ...options, ...attrs, path: ctx.request.path};
   const utm = Object.keys(etagObj).filter((k) => k.startsWith('utm_'));
   for (const key of utm) {

--- a/src/holidayCommon.js
+++ b/src/holidayCommon.js
@@ -1,5 +1,5 @@
 import dayjs from 'dayjs';
-import {flags, HDate, HebrewCalendar} from '@hebcal/core';
+import {flags, HDate, getSedra} from '@hebcal/core';
 import {makeAnchor, getHolidayDescription, getEventCategories} from '@hebcal/rest-api';
 import {holidayMeta} from './holidayMeta.js';
 import {getNumYears} from './calendar.js';
@@ -205,7 +205,7 @@ export function eventToHolidayItem(ev, il) {
     categories: getEventCategories(ev),
   });
   if ((mask & flags.SPECIAL_SHABBAT) && !staticSpecial.has(item.name)) {
-    const sedra = HebrewCalendar.getSedra(hd.getFullYear(), il);
+    const sedra = getSedra(hd.getFullYear(), il);
     const parsha0 = sedra.lookup(hd);
     if (!parsha0.chag) {
       item.parsha = parsha0.parsha;

--- a/src/holidayDetail.js
+++ b/src/holidayDetail.js
@@ -1,4 +1,5 @@
-import {flags, greg, HDate, HebrewCalendar, Locale, months, Event, ParshaEvent, HolidayEvent} from '@hebcal/core';
+import {flags, greg, HDate, HebrewCalendar, Locale, months, Event, ParshaEvent,
+  HolidayEvent, getSedra} from '@hebcal/core';
 import {getLeyningKeyForEvent, getLeyningForHolidayKey, getLeyningForHoliday,
   getLeyningForParshaHaShavua, hasFestival} from '@hebcal/leyning';
 import {addLinksToLeyning, makeLeyningHtmlFromParts} from './parshaCommon.js';
@@ -515,7 +516,7 @@ function makeHolidayReading(holiday, item, meta, reading, ev, il) {
   }
   if (ev?.getDate().getDay() === 6 && (ev.getFlags() & SAT_OVERLAY_FLAGS)) {
     const hd = ev.getDate();
-    const sedra = HebrewCalendar.getSedra(hd.getFullYear(), il);
+    const sedra = getSedra(hd.getFullYear(), il);
     const parsha = sedra.lookup(hd);
     if (!parsha.chag) {
       itemReading.parsha = parsha.parsha;
@@ -537,7 +538,7 @@ function getReadingForHoliday(ev, il) {
   if (desc === 'Chanukah: 1 Candle') {
     return undefined;
   } else if (hd.getDay() === 6 && (ev.getFlags() & SAT_OVERLAY_FLAGS)) {
-    const sedra = HebrewCalendar.getSedra(hd.getFullYear(), il);
+    const sedra = getSedra(hd.getFullYear(), il);
     const parsha = sedra.lookup(hd);
     if (!parsha.chag) {
       const pe = new ParshaEvent(parsha);

--- a/src/homepage.js
+++ b/src/homepage.js
@@ -1,5 +1,5 @@
-import {HDate, HebrewCalendar, months, ParshaEvent, flags, Locale,
-  DailyLearning, ChanukahEvent} from '@hebcal/core';
+import {HDate, HebrewCalendar, months, ParshaEvent, flags, Locale, DailyLearning,
+  ChanukahEvent, getHolidaysOnDate, getSedra} from '@hebcal/core';
 import '@hebcal/learning';
 import {getDefaultYear, getSunsetAwareDate} from './dateUtil.js';
 import {setDefautLangTz} from './defaultLangTz.js';
@@ -135,7 +135,7 @@ function mastheadCandles(ctx, dt, il) {
 function mastheadParsha(ctx, hd, il) {
   const items = ctx.state.items;
   const saturday = hd.onOrAfter(6);
-  const sedra = HebrewCalendar.getSedra(saturday.getFullYear(), il);
+  const sedra = getSedra(saturday.getFullYear(), il);
   const parsha = sedra.lookup(saturday);
   if (!parsha.chag) {
     const pe = new ParshaEvent(parsha);
@@ -240,7 +240,7 @@ function getMastheadGreeting(ctx, hd, il, dateOverride) {
     return [blurb, longText];
   }
 
-  const holidays = HebrewCalendar.getHolidaysOnDate(hd, il) || [];
+  const holidays = getHolidaysOnDate(hd, il) || [];
   if (holidays.some((ev) => ev.getDesc() === 'Erev Tish\'a B\'Av')) {
     return [TZOM_KAL, `<a class="text-green1 text-nowrap" href="/holidays/tisha-bav-${gy}">Tish'a B'Av</a>
  begins tonight at sundown. We wish you an easy fast`];
@@ -293,7 +293,7 @@ function getMastheadGreeting(ctx, hd, il, dateOverride) {
     return getHolidayGreeting(ctx, chagToday, il, true, dateOverride);
   }
 
-  const tomorrow = HebrewCalendar.getHolidaysOnDate(hd.next(), il) || [];
+  const tomorrow = getHolidaysOnDate(hd.next(), il) || [];
   const chagTomorrow = tomorrow.find((ev) => !(ev.getFlags() & flags.EREV) && chagSameach[ev.basename()]);
   if (chagTomorrow) {
     return getHolidayGreeting(ctx, chagTomorrow, il, false);
@@ -406,7 +406,7 @@ function getHolidayGreeting(ctx, ev, il, today, dateOverride) {
     const d = dayjs.tz(new Date(), tzid);
     const dt = new Date(d.year(), d.month(), d.date());
     const hd = new HDate(dt);
-    const holidays = HebrewCalendar.getHolidaysOnDate(hd, il) || [];
+    const holidays = getHolidaysOnDate(hd, il) || [];
     const ev2 = holidays.find((ev) => ev.getFlags() & flags.CHANUKAH_CANDLES);
     if (ev2) {
       return getChanukahGreeting(d, ev2);

--- a/src/omerApp.js
+++ b/src/omerApp.js
@@ -4,7 +4,7 @@ import {httpRedirect} from './common.js';
 import {CACHE_CONTROL_1_YEAR, CACHE_CONTROL_30DAYS} from './cacheControl.js';
 import {getDefaultHebrewYear, yearIsOutsideHebRange} from './dateUtil.js';
 import {basename, dirname} from 'node:path';
-import {HDate, months, OmerEvent, HebrewCalendar, Locale} from '@hebcal/core';
+import {HDate, months, OmerEvent, Locale, getHolidaysOnDate} from '@hebcal/core';
 import {makeDownloadProps} from './makeDownloadProps.js';
 import {getHolidayMeta} from './getHolidayMeta.js';
 
@@ -91,7 +91,7 @@ export async function omerApp(rpath, ctx) {
   const beginOmer = HDate.hebrew2abs(hyear, months.NISAN, 16);
   const hd = new HDate(beginOmer + omerDay - 1);
   const ev = new OmerEvent(hd, omerDay);
-  const holidays = HebrewCalendar.getHolidaysOnDate(hd, false) || [];
+  const holidays = getHolidaysOnDate(hd, false) || [];
   const prev = omerDay === 1 ? 49 : omerDay - 1;
   const next = omerDay === 49 ? 1 : omerDay + 1;
   return ctx.render('omer', {

--- a/src/parshaCommon.js
+++ b/src/parshaCommon.js
@@ -1,4 +1,4 @@
-import {HebrewCalendar, Locale, parshiot, flags} from '@hebcal/core';
+import {Locale, parshiot, flags, getHolidaysOnDate} from '@hebcal/core';
 import {formatAliyahShort, lookupParsha, makeSummaryFromParts} from '@hebcal/leyning';
 import {makeAnchor, eventToCsv, CSV_HEADER} from '@hebcal/rest-api';
 import {langNames} from './lang.js';
@@ -312,7 +312,7 @@ const PARSHA_SPECIAL_MASK = flags.SPECIAL_SHABBAT | flags.ROSH_CHODESH;
 function getCsvParshaMemo(ev, il, locale) {
   if (ev.getFlags() & flags.PARSHA_HASHAVUA) {
     const hd = ev.getDate();
-    const holidays0 = HebrewCalendar.getHolidaysOnDate(hd, il) || [];
+    const holidays0 = getHolidaysOnDate(hd, il) || [];
     const holidays1 = holidays0.filter((ev) => Boolean(ev.getFlags() & PARSHA_SPECIAL_MASK));
     if (holidays1.length) {
       return holidays1.map((ev) => ev.render(locale)).join(' + ');

--- a/src/parshaIndex.js
+++ b/src/parshaIndex.js
@@ -1,4 +1,4 @@
-import {HebrewCalendar, HDate, ParshaEvent} from '@hebcal/core';
+import {HDate, ParshaEvent, getHolidaysOnDate, getSedra} from '@hebcal/core';
 import {Triennial} from '@hebcal/triennial';
 import {getSunsetAwareDate, expiresSaturdayNight} from './dateUtil.js';
 import {checkFreshETag} from './etag.js';
@@ -81,7 +81,7 @@ function getTodayHolidayEvent(hd, il) {
   if (hd.getDay() === 6) {
     return undefined;
   }
-  const events = HebrewCalendar.getHolidaysOnDate(hd, il) || [];
+  const events = getHolidaysOnDate(hd, il) || [];
   for (const ev of events) {
     const reading = getLeyningForHoliday(ev, il);
     const url = shortenUrl(ev.url());
@@ -95,11 +95,11 @@ function getTodayHolidayEvent(hd, il) {
 }
 
 function getParsha(hd, il) {
-  const sedra = HebrewCalendar.getSedra(hd.getFullYear(), il);
+  const sedra = getSedra(hd.getFullYear(), il);
   const parsha0 = sedra.lookup(hd);
   const parsha = parsha0.parsha.join('-');
   if (parsha0.chag) {
-    const events = HebrewCalendar.getHolidaysOnDate(hd, il) || [];
+    const events = getHolidaysOnDate(hd, il) || [];
     if (events.length > 0) {
       const ev = events[0];
       const href = shortenUrl(ev.url());

--- a/src/parshaYear.js
+++ b/src/parshaYear.js
@@ -1,4 +1,4 @@
-import {HebrewCalendar, HDate, flags, months, ParshaEvent} from '@hebcal/core';
+import {HDate, flags, months, ParshaEvent, getHolidaysOnDate, getSedra} from '@hebcal/core';
 import {getLeyningKeyForEvent, getLeyningForParshaHaShavua,
   getLeyningForHoliday, makeLeyningParts} from '@hebcal/leyning';
 import {makeLeyningHtmlFromParts} from './parshaCommon.js';
@@ -30,14 +30,14 @@ export async function parshaYearApp(ctx) {
   const il = q.i === 'on';
   const lang = lgToLocale[q.lg || 's'] || q.lg;
   const locale = localeMap[lang] || 'en';
-  const sedra = HebrewCalendar.getSedra(hyear, il);
+  const sedra = getSedra(hyear, il);
   const startAbs = sedra.getFirstSaturday();
   const endAbs = HDate.hebrew2abs(hyear + 1, months.TISHREI, 1);
   const events = [];
   for (let abs = startAbs; abs < endAbs; abs += 7) {
     const parsha = sedra.lookup(abs);
     if (parsha.chag) {
-      const holidays = HebrewCalendar.getHolidaysOnDate(abs, il) || [];
+      const holidays = getHolidaysOnDate(abs, il) || [];
       events.push(...holidays);
     } else {
       const ev = new ParshaEvent(parsha);
@@ -111,7 +111,7 @@ function makeItem(ev, locale, il, lang) {
     item.torahHtml = makeLeyningHtmlFromParts(parts);
   }
   if (isParsha) {
-    const holidays0 = HebrewCalendar.getHolidaysOnDate(hd, il) || [];
+    const holidays0 = getHolidaysOnDate(hd, il) || [];
     const mask = flags.SPECIAL_SHABBAT | flags.ROSH_CHODESH;
     const holidays1 = holidays0.filter((ev) => (ev.getFlags() & mask) || ev.chanukahDay);
     item.holidays = holidays1.map((ev) => holidayEvToItem(ev, il, lang));

--- a/src/sedrot.js
+++ b/src/sedrot.js
@@ -1,4 +1,4 @@
-import {HebrewCalendar, HDate, ParshaEvent, Locale, parshiot} from '@hebcal/core';
+import {HebrewCalendar, HDate, ParshaEvent, Locale, parshiot, getSedra} from '@hebcal/core';
 import {makeAnchor} from '@hebcal/rest-api';
 import {getLeyningForParshaHaShavua, getLeyningForParsha, parshaToString} from '@hebcal/leyning';
 import {Triennial, getTriennial, getTriennialForParshaHaShavua} from '@hebcal/triennial';
@@ -267,7 +267,7 @@ function doIsraelDiasporaDiffer(parsha, il, hd, triennial) {
     }
     return [false, '', ''];
   }
-  const otherSedra = HebrewCalendar.getSedra(hyear, !il);
+  const otherSedra = getSedra(hyear, !il);
   const otherParsha = otherSedra.lookup(hd);
   const otherParshaName = parshaToString(otherParsha.parsha);
   if (parshaName !== otherParshaName) {

--- a/src/shabbat-browse.js
+++ b/src/shabbat-browse.js
@@ -1,4 +1,4 @@
-import {HDate, HebrewCalendar, Location, Zmanim} from '@hebcal/core';
+import {HDate, HebrewCalendar, Location, Zmanim, getHolidaysOnDate, getSedra} from '@hebcal/core';
 import {makeAnchor} from '@hebcal/rest-api';
 // eslint-disable-next-line n/no-unsupported-features/node-builtins
 import {DatabaseSync} from 'node:sqlite';
@@ -301,11 +301,11 @@ function makeCandleLighting(ctx, results, countryCode) {
 function getParsha(saturday, il) {
   const hd = new HDate(saturday.toDate());
   const hyear = hd.getFullYear();
-  const sedra = HebrewCalendar.getSedra(hyear, il);
+  const sedra = getSedra(hyear, il);
   const parsha0 = sedra.lookup(hd);
   let parsha = null;
   if (parsha0.chag) {
-    const events = HebrewCalendar.getHolidaysOnDate(hd, il) || [];
+    const events = getHolidaysOnDate(hd, il) || [];
     if (events.length > 0) {
       parsha = events[0].basename();
     }


### PR DESCRIPTION
`HebrewCalendar.getHolidaysOnDate()` and `HebrewCalendar.getSedra()` are one-line static wrappers around functions `@hebcal/core` already exports at its root:

```js
static getHolidaysOnDate(date, il) {
  return getHolidaysOnDate(date, il);
}
```

`HebrewCalendar.version()` likewise just returns the exported `version` string. Import all three directly.

## Converted — 22 sites, 12 files

| static | sites |
|---|---|
| `HebrewCalendar.getHolidaysOnDate()` | 12 |
| `HebrewCalendar.getSedra()` | 9 |
| `HebrewCalendar.version()` | 1 |

Six modules no longer need the `HebrewCalendar` class at all: `parshaCommon.js`, `parshaIndex.js`, `omerApp.js`, `holidayCommon.js`, `parshaYear.js`, `etag.js`.

`getSedra()` was checked to return the identical memoized `Sedra` instance, not a fresh one.

The `version` change is the only one that alters call shape — `HebrewCalendar.version()` → `coreVersion`, aliased on import because a bare `version` reads badly next to `pkg.version` in `etag.js`. It feeds the ETag hash, so the value was confirmed to be `"6.8.2"` directly rather than inferred from a green test run; `undefined` there would have silently changed every ETag instead of failing anything.

## Left alone — no bare export

- **`HebrewCalendar.calendar()`** (60 sites). Not exported at root, and unlike the others it isn't a wrapper — it's the real implementation on the class.
- **`HebrewCalendar.reformatTimeStr()`** (7 sites). This one *is* a pure delegating wrapper and the bare function is reachable, since the package's export map exposes `./dist/esm/*` — that's how `@hebcal/rest-api` imports it. Skipped deliberately: a deep import pins us to the package's internal file layout, which is a worse trade than one wrapper call. Probably worth asking upstream to re-export it from the root alongside `getSedra` and `getHolidaysOnDate`.
- **`HebrewCalendar.getYahrzeit()` / `getBirthdayOrAnniversary()`** (`yahrzeitEvents.js:182-183`). No bare export, not even a deep one.

## Testing

`npm test` → 580 passed, 8 skipped. `oxlint` clean. No behavior change, so no new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
