### PR TITLE
Compare event descriptions against holidayDesc constants

### DIFF
--- a/src/converter.js
+++ b/src/converter.js
@@ -1,5 +1,5 @@
 import {HDate, HebrewCalendar, Event, ParshaEvent, Locale, months, OmerEvent, gematriya,
-  greg, getHolidaysOnDate, getSedra} from '@hebcal/core';
+  greg, getHolidaysOnDate, getSedra, holidayDesc as hdesc} from '@hebcal/core';
 import dayjs from 'dayjs';
 import {checkFreshETag} from './etag.js';
 import {httpRedirect, hebrewFontPreload, jsonpBody} from './common.js';
@@ -414,7 +414,7 @@ function getEvents(hdate, il) {
     shabbatMevarchim: true,
     molad: true,
   });
-  events = events.filter((ev) => ev.getDesc() !== 'Chanukah: 1 Candle');
+  events = events.filter((ev) => ev.getDesc() !== hdesc.CHANUKAH_1_CANDLE);
   events = events.concat(getParshaEvents(hdate, il));
   events = events.concat(makeOmer(hdate));
   return events;

--- a/src/fridge.js
+++ b/src/fridge.js
@@ -1,4 +1,5 @@
-import {HebrewCalendar, Locale, HDate, flags, months, greg} from '@hebcal/core';
+import {HebrewCalendar, Locale, HDate, flags, months, greg,
+  holidayDesc as hdesc} from '@hebcal/core';
 import {empty} from './empty.js';
 import {checkFreshETag} from './etag.js';
 import {setDefautLangTz} from './defaultLangTz.js';
@@ -158,14 +159,14 @@ function makeContents(events, options) {
   for (let i = 0; i < events.length; i++) {
     const ev = events[i];
     const desc = ev.getDesc();
-    if (desc === 'Havdalah') {
+    if (desc === hdesc.HAVDALAH) {
       if (objs.length) {
         objs.at(-1).havdalah =
           HebrewCalendar.reformatTimeStr(ev.eventTimeStr, '', options);
       }
       continue;
     }
-    if (desc !== 'Candle lighting') {
+    if (desc !== hdesc.CANDLE_LIGHTING) {
       continue;
     }
     const hd = ev.getDate();

--- a/src/holidayDetail.js
+++ b/src/holidayDetail.js
@@ -1,5 +1,5 @@
 import {flags, greg, HDate, HebrewCalendar, Locale, months, Event, ParshaEvent,
-  HolidayEvent, getSedra} from '@hebcal/core';
+  HolidayEvent, getSedra, holidayDesc as hdesc} from '@hebcal/core';
 import {getLeyningKeyForEvent, getLeyningForHolidayKey, getLeyningForHoliday,
   getLeyningForParshaHaShavua, hasFestival} from '@hebcal/leyning';
 import {addLinksToLeyning, makeLeyningHtmlFromParts} from './parshaCommon.js';
@@ -535,7 +535,7 @@ const SAT_OVERLAY_FLAGS = flags.SPECIAL_SHABBAT | flags.ROSH_CHODESH |
 function getReadingForHoliday(ev, il) {
   const hd = ev.getDate();
   const desc = ev.getDesc();
-  if (desc === 'Chanukah: 1 Candle') {
+  if (desc === hdesc.CHANUKAH_1_CANDLE) {
     return undefined;
   } else if (hd.getDay() === 6 && (ev.getFlags() & SAT_OVERLAY_FLAGS)) {
     const sedra = getSedra(hd.getFullYear(), il);

--- a/src/homepage.js
+++ b/src/homepage.js
@@ -1,5 +1,5 @@
 import {HDate, HebrewCalendar, months, ParshaEvent, flags, Locale, DailyLearning,
-  ChanukahEvent, getHolidaysOnDate, getSedra} from '@hebcal/core';
+  ChanukahEvent, getHolidaysOnDate, getSedra, holidayDesc as hdesc} from '@hebcal/core';
 import '@hebcal/learning';
 import {getDefaultYear, getSunsetAwareDate} from './dateUtil.js';
 import {setDefautLangTz} from './defaultLangTz.js';
@@ -241,16 +241,16 @@ function getMastheadGreeting(ctx, hd, il, dateOverride) {
   }
 
   const holidays = getHolidaysOnDate(hd, il) || [];
-  if (holidays.some((ev) => ev.getDesc() === 'Erev Tish\'a B\'Av')) {
+  if (holidays.some((ev) => ev.getDesc() === hdesc.EREV_TISHA_BAV)) {
     return [TZOM_KAL, `<a class="text-green1 text-nowrap" href="/holidays/tisha-bav-${gy}">Tish'a B'Av</a>
  begins tonight at sundown. We wish you an easy fast`];
   }
-  if (holidays.some((ev) => ev.getDesc() === 'Yom HaShoah')) {
+  if (holidays.some((ev) => ev.getDesc() === hdesc.YOM_HASHOAH)) {
     return ['✡️ We remember ✡️',
       `Today is <a class="text-green1 text-nowrap" href="/holidays/yom-hashoah-${gy}">Yom HaShoah</a>,
  Holocaust and Heroism Remembrance Day`];
   }
-  if (holidays.some((ev) => ev.getDesc() === 'Yom HaZikaron')) {
+  if (holidays.some((ev) => ev.getDesc() === hdesc.YOM_HAZIKARON)) {
     return ['🇮🇱 <span lang="he" dir="rtl">אנחנו זוכרים אותם</span> 🇮🇱',
       `Today is <a class="text-green1 text-nowrap" href="/holidays/yom-hazikaron-${gy}">Yom HaZikaron</a>,
  Israeli Memorial Day`];
@@ -281,7 +281,7 @@ function getMastheadGreeting(ctx, hd, il, dateOverride) {
     // immediately after Rosh Chodesh Kislev, show Chanukah greeting
     const erevHd = new HDate(24, months.KISLEV, yy);
     const erevEv = new ChanukahEvent(erevHd,
-        'Chanukah: 1 Candle', flags.CHANUKAH_CANDLES, undefined);
+        hdesc.CHANUKAH_1_CANDLE, flags.CHANUKAH_CANDLES, undefined);
     const d = dayjs(erevHd.greg()).locale(locale);
     const [, longText] = getChanukahGreeting(d, erevEv);
     return ['🕎&nbsp;<span lang="he" dir="rtl">חֲנוּכָּה שָׂמֵחַ</span>&nbsp;🕎',

--- a/src/icalCommon.js
+++ b/src/icalCommon.js
@@ -1,4 +1,4 @@
-import {flags} from '@hebcal/core';
+import {flags, holidayDesc as hdesc} from '@hebcal/core';
 import {IcalEvent, icalEventsToString} from '@hebcal/icalendar';
 import {
   appendIsraelAndTracking,
@@ -45,7 +45,7 @@ function appendTrackingToUrl(url, options) {
 export function createMemo(ev, options) {
   let memo = ev.memo || '';
   const desc = ev.getDesc();
-  if (desc === 'Havdalah' || desc === 'Candle lighting') {
+  if (desc === hdesc.HAVDALAH || desc === hdesc.CANDLE_LIGHTING) {
     return memo;
   }
   const mask = ev.getFlags();


### PR DESCRIPTION
`rss.js` and `fullcalendar.js` already import `holidayDesc as hdesc` and write:

```js
const candles = desc === hdesc.HAVDALAH || desc === hdesc.CANDLE_LIGHTING;
```

`icalCommon.js:48` had the *identical* expression spelled with string literals. This makes the idiom consistent: use the constants everywhere an event description is compared or constructed, so an upstream rename becomes a resolution error in one place instead of a comparison that silently stops matching.

## Converted — 9 literals, 5 files

| file | was |
|---|---|
| `icalCommon.js:48` | `desc === 'Havdalah' \|\| desc === 'Candle lighting'` |
| `fridge.js:161,168` | `desc === 'Havdalah'`, `desc !== 'Candle lighting'` |
| `converter.js:417` | `ev.getDesc() !== 'Chanukah: 1 Candle'` |
| `holidayDetail.js:537` | `desc === 'Chanukah: 1 Candle'` |
| `homepage.js:244,248,253` | `ev.getDesc() === 'Erev Tish'a B'Av'` / `'Yom HaShoah'` / `'Yom HaZikaron'` |
| `homepage.js:284` | `new ChanukahEvent(erevHd, 'Chanukah: 1 Candle', …)` |

A misspelled constant would be `undefined` and turn a comparison silently always-false — and the `homepage.js` greetings only fire on particular dates, so the tests would not necessarily catch it. Every replaced constant was asserted to resolve back to the exact literal it replaced, rather than relying on the green test run.

## Deliberately left as literals

**`ev.basename()` comparisons and basename-keyed maps** — `holidayCommon.js`, `holidayIndex.js`, `holidayYearIndex.js`, `homepage.js`. `basename()` strips the day suffix, and the four biggest holidays have **no** `holidayDesc` constant for their base form:

| basename | constant |
|---|---|
| `Rosh Hashana` | — none (only `ROSH_HASHANA_5786`-style descs exist) |
| `Sukkot` | — none |
| `Pesach` | — none |
| `Chanukah` | — none |
| `Yom Kippur`, `Shavuot`, `Purim`, … | present |

So `holidayYearIndex.js`'s `groupings` object and `holidayIndex.js`'s `tableCellObserved` switch could only be *half* converted, leaving `[hdesc.YOM_KIPPUR]:` sitting next to `'Rosh Hashana':` in the same literal. That reads worse than leaving it alone, so none of them were touched.

**`Locale.gettext('Candle lighting', p.locale)`** in `fridge.js:113` — a key into our own `po/` catalogs, not an event description. Coupling it to the library constant would let the two drift apart and break i18n lookups silently.

**Test assertions** — ~40 matches across `test/`. These pin user-visible rendered output on purpose; if the library changed a string out from under a page, `expect(response.text).toContain('Yom Kippur')` *should* fail rather than follow the rename.

## Testing

`npm test` → 580 passed, 8 skipped. `oxlint` clean. Pure substitution of identical string values, so no new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
