### PR TITLE
test: use italy-lombardy instead of italy-calabria for browse page

### DIFF
--- a/test/shabbat.test.js
+++ b/test/shabbat.test.js
@@ -26,7 +26,7 @@ describe('Shabbat Routes', () => {
     ['/shabbat?geonameid=293397&M=on&lg=h&gy=2025&gm=12&gd=24', 'html'],
     ['/shabbat?cfg=json&geonameid=293397&M=on&lg=h&gy=2025&gm=12&gd=24', 'json'],
     ['/shabbat/?geonameid=5128581', 'html'],
-    ['/shabbat/browse/italy-calabria', 'html'],
+    ['/shabbat/browse/italy-lombardy', 'html'],
     ['/shabbat/browse/sitemap.xml', 'xml'],
     ['/shabbat/browse/australia.xml', 'xml'],
   ])('should return 200 %s (%s)', async (url, type) => {
@@ -113,8 +113,8 @@ describe('Shabbat 304 Not Modified (ETag / If-None-Match)', () => {
     await expectConditionalEtag(server, '/shabbat/browse/australia.xml');
   });
 
-  // Small admin1-region page (e.g. Calabria, Italy).
+  // Small admin1-region page (e.g. Lombardy, Italy).
   it('handles conditional requests for a browse small-region page', async () => {
-    await expectConditionalEtag(server, '/shabbat/browse/italy-calabria');
+    await expectConditionalEtag(server, '/shabbat/browse/italy-lombardy');
   });
 });


### PR DESCRIPTION
The MIN_POPULATION >= 1000 filter added to the Shabbat browse pages
excludes Calabria's only city in the test geonames database (Amato,
population 895), so /shabbat/browse/italy-calabria now 404s.

Switch to Lombardy, which is still a small single-city admin1 region in
the test database (San Michele-San Giorgio, population 5040) and so
continues to exercise the same country-admin1 render and ETag paths.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HqnNTk7qdP592nyYz1bDwz