### PR TITLE
Add /leyning?events=on, and resolve lg through lgToLocale in /converter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,18 @@ Each feature is typically one or a few files handling routing, business logic, a
   descriptions over time and now embeds Markdown in some of them; drash.json
   holds plain text, so re-scraping means flattening `[text](url)` and
   `*emphasis*` first.
+- **Torah readings**: `leyning.js` (`/leyning?cfg=json`) wraps
+  `getLeyningOnDate()`. The optional `&events=on` exists for
+  [hebcal-api-go](https://github.com/hebcal/hebcal-api-go), whose `/shabbat`
+  renders one reading per calendar event the way
+  `eventToClassicApiObject()` does. It labels each holiday reading with the
+  `desc` of the events that produce it, and adds back the holiday readings
+  `getLeyningOnDate()` drops on a Shabbat that also has a parsha (Rosh
+  Chodesh, the special Shabbatot) because their maftir and Haftarah are
+  folded into the parsha reading. Those readings are not always
+  reconstructable from the parsha item — Shabbat Shuva's own Haftarah has a
+  third part the "(with Vayeilech)" variant lacks — so they have to be
+  emitted separately. Without `events=on` the response is unchanged.
 - **Daily learning**: `dailyLearning.js` (Daf Yomi, etc.)
 - **Email subscriptions**: `email.js`, `emailCommon.js`
 - **Geolocation**: `location.js`, `nearestCity.js`, `defaultLangTz.js`

--- a/src/converter.js
+++ b/src/converter.js
@@ -39,9 +39,14 @@ export async function hebrewDateConverter(ctx) {
     await setDefautLangTz(ctx);
   }
   const q = ctx.request.query;
-  ctx.state.lg = q.lg || 's';
-  const lg = lgToLocale[ctx.state.lg] || ctx.state.lg;
-  ctx.state.locale = localeMap[lg] || 'en';
+  // Resolve lg through lgToLocale before rendering anything, the way
+  // makeHebcalOptions() does for /shabbat and /hebcal. Everything downstream
+  // renders from ctx.state.lg, and @hebcal/hdate's own alias table knows only
+  // a/h/s, so without this the "+ Hebrew" spellings ah and sh fell through to
+  // English instead of Ashkenazi and Sephardic transliteration. The language
+  // menus read q.lg rather than ctx.state.lg, so they still round-trip.
+  ctx.state.lg = lgToLocale[q.lg] || q.lg || 's';
+  ctx.state.locale = localeMap[ctx.state.lg] || 'en';
   let props;
   try {
     props = parseConverterQuery(ctx);

--- a/src/leyning.js
+++ b/src/leyning.js
@@ -1,5 +1,5 @@
-import {ParshaEvent, HDate} from '@hebcal/core';
-import {getLeyningOnDate} from '@hebcal/leyning';
+import {ParshaEvent, HDate, getHolidaysOnDate} from '@hebcal/core';
+import {getLeyningOnDate, getLeyningForHoliday} from '@hebcal/leyning';
 import {getTriennialForParshaHaShavua} from '@hebcal/triennial';
 import {isoDateStringToDate} from './dateUtil.js';
 import {checkFreshETag} from './etag.js';
@@ -46,10 +46,12 @@ export async function getLeyning(ctx) {
 
   const startHd = new HDate(startD.toDate());
   const doTriennial = q.triennial !== 'off' && startHd.getFullYear() >= 5745;
+  const byEvent = q.events === 'on';
   const items = [];
   for (let d = startD; d.isSameOrBefore(endD, 'd'); d = d.add(1, 'd')) {
     const hd = new HDate(d.toDate());
     const readings = getLeyningOnDate(hd, il, true);
+    const dayItems = [];
     for (const reading of readings) {
       const item = makeReadingItem(d, hd, reading);
       if (doTriennial && reading.parsha && hd.getDay() === 6) {
@@ -60,8 +62,12 @@ export async function getLeyning(ctx) {
         item.triHaftara = triReading.haftara;
         item.triHaft = triReading.haft;
       }
-      items.push(item);
+      dayItems.push(item);
     }
+    if (byEvent) {
+      addHolidayEvents(dayItems, d, hd, il);
+    }
+    items.push(...dayItems);
   }
 
   const result = {
@@ -75,6 +81,43 @@ export async function getLeyning(ctx) {
   };
 
   ctx.body = result;
+}
+
+/**
+ * Labels each holiday reading with the `desc` of every holiday event that
+ * produces it, and appends the holiday readings that `getLeyningOnDate()`
+ * leaves out on a Shabbat that also has a parsha (Rosh Chodesh and the
+ * special Shabbatot, whose maftir and Haftarah are folded into the parsha
+ * reading instead).
+ *
+ * Enabled by `&events=on`. Callers that render one reading per calendar event
+ * — the way `eventToClassicApiObject()` in `@hebcal/rest-api` does, by calling
+ * `getLeyningForHoliday()` for each event — need both: a reading for
+ * "Shabbat Shekalim" itself, and a way to tell which event each reading
+ * belongs to. Readings with no matching event (weekday, Mincha, Erev Simchat
+ * Torah) simply come back without a `desc`.
+ * @private
+ * @param {any[]} dayItems readings already found for this date; appended to
+ * @param {dayjs.Dayjs} d
+ * @param {HDate} hd
+ * @param {boolean} il
+ */
+function addHolidayEvents(dayItems, d, hd, il) {
+  const byName = new Map(dayItems.map((item) => [item.name.en, item]));
+  for (const ev of getHolidaysOnDate(hd, il) || []) {
+    const reading = getLeyningForHoliday(ev, il);
+    if (!reading) {
+      continue;
+    }
+    let item = byName.get(reading.name.en);
+    if (!item) {
+      item = makeReadingItem(d, hd, reading);
+      byName.set(reading.name.en, item);
+      dayItems.push(item);
+    }
+    item.desc ??= [];
+    item.desc.push(ev.getDesc());
+  }
 }
 
 /**

--- a/test/converter.test.js
+++ b/test/converter.test.js
@@ -152,3 +152,32 @@ describe('Converter h2g ndays', () => {
     expect(response.status).toBe(400);
   });
 });
+
+describe('Converter language', () => {
+  const url = '/converter?cfg=json&gy=2026&gm=11&gd=7&g2h=1';
+
+  it('should render events in the requested language', async () => {
+    const cases = {
+      's': 'Parashat Chayei Sara',
+      'a': 'Parshas Chayei Sara',
+      'sh': 'Parashat Chayei Sara',
+      // ah is Ashkenazi transliteration plus Hebrew in email subject lines;
+      // @hebcal/hdate's own alias table does not know it, so lgToLocale has
+      // to resolve it before anything renders
+      'ah': 'Parshas Chayei Sara',
+      'h': 'פָּרָשַׁת חַיֵּי שָֹרָה',
+      'fr': 'Parachah H̲ayé Sarah',
+    };
+    for (const [lg, parsha] of Object.entries(cases)) {
+      const response = await request(server).get(`${url}&lg=${lg}`);
+      expect(response.status).toBe(200);
+      expect(response.body.events, `lg=${lg}`).toContain(parsha);
+    }
+  });
+
+  it('should default to Sephardic transliteration', async () => {
+    const response = await request(server).get(url);
+    expect(response.status).toBe(200);
+    expect(response.body.events).toContain('Parashat Chayei Sara');
+  });
+});

--- a/test/misc.test.js
+++ b/test/misc.test.js
@@ -157,6 +157,62 @@ describe('Leyning Routes', () => {
     const item = response.body.items[0];
     expect(item.consolation).toBe('3,5');
   });
+
+  it('should not label readings with events unless events=on', async () => {
+    const response = await request(server)
+        .get('/leyning?cfg=json&date=2026-02-14');
+    expect(response.status).toBe(200);
+    expect(response.body.items.map((i) => i.name.en)).toEqual(['Mishpatim']);
+    expect(response.body.items[0].desc).toBeUndefined();
+  });
+
+  it('should label holiday readings with their events when events=on', async () => {
+    const response = await request(server)
+        .get('/leyning?cfg=json&date=2025-12-22&events=on');
+    expect(response.status).toBe(200);
+    expect(response.body.items).toHaveLength(1);
+    expect(response.body.items[0].name.en).toBe('Chanukah Day 8');
+    expect(response.body.items[0].desc).toEqual(['Chanukah: 8th Day']);
+  });
+
+  it('should list every event sharing one reading when events=on', async () => {
+    // 1 Tevet 5786 is both Rosh Chodesh and the 7th day of Chanukah, and
+    // the two events resolve to the same reading key.
+    const response = await request(server)
+        .get('/leyning?cfg=json&date=2025-12-21&events=on');
+    expect(response.status).toBe(200);
+    expect(response.body.items).toHaveLength(1);
+    expect(response.body.items[0].name.en).toBe('Chanukah Day 7 (on Rosh Chodesh)');
+    expect(response.body.items[0].desc).toEqual(['Chanukah: 8 Candles', 'Rosh Chodesh Tevet']);
+  });
+
+  it('should add the special Shabbat reading suppressed by the parsha when events=on', async () => {
+    // Shabbat Shekalim 2026-02-14: getLeyningOnDate() folds the special
+    // maftir and Haftarah into Parashat Mishpatim and drops the standalone
+    // reading, which callers rendering one reading per event still need.
+    const response = await request(server)
+        .get('/leyning?cfg=json&date=2026-02-14&events=on');
+    expect(response.status).toBe(200);
+    const byName = Object.fromEntries(response.body.items.map((i) => [i.name.en, i]));
+    expect(Object.keys(byName).sort()).toEqual(['Mishpatim', 'Shabbat Shekalim']);
+    expect(byName['Mishpatim'].desc).toBeUndefined();
+    expect(byName['Shabbat Shekalim'].desc).toEqual(['Shabbat Shekalim']);
+    expect(byName['Shabbat Shekalim'].haftara).toBe('II Kings 12:1-17');
+    expect(byName['Shabbat Shekalim'].fullkriyah.M).toMatchObject({
+      k: 'Exodus', b: '30:11', e: '30:16',
+    });
+  });
+
+  it('should leave weekday and Mincha readings unlabeled when events=on', async () => {
+    // Yom Kippur 2025-10-02 has both a morning and a Mincha reading; only
+    // the morning one belongs to the Yom Kippur event.
+    const response = await request(server)
+        .get('/leyning?cfg=json&date=2025-10-02&events=on');
+    expect(response.status).toBe(200);
+    const byName = Object.fromEntries(response.body.items.map((i) => [i.name.en, i]));
+    expect(byName['Yom Kippur'].desc).toEqual(['Yom Kippur']);
+    expect(byName['Yom Kippur (Mincha)'].desc).toBeUndefined();
+  });
 });
 
 describe('Delete Cookie Route', () => {


### PR DESCRIPTION
Two changes, both driven by porting `/shabbat?cfg=json` to Go in [hebcal-api-go](https://github.com/hebcal/hebcal-api-go). That service has no leyning data of its own, so it fetches readings from `/leyning` over HTTP.

## `/leyning?cfg=json&events=on` (opt-in)

`getLeyningOnDate()` answers "what is read on this date". `eventToClassicApiObject()` in `@hebcal/rest-api` asks a different question — it calls `getLeyningForHoliday()` once per calendar event — and the two disagree in two ways:

1. **Readings go missing.** On a Shabbat that also has a parsha, `getLeyningOnDate()` drops the Rosh Chodesh and special-Shabbat readings, because their maftir and Haftarah are folded into the parsha reading. But `/shabbat?cfg=json` emits a `leyning` object for the "Shabbat Shekalim" item itself, not only for "Parashat Mishpatim". That is roughly 12 Shabbatot a year.

2. **Nothing says which event a reading belongs to.** A holiday reading comes back keyed by its `holiday-readings.json` name; matching it back to an event means reimplementing `getLeyningKeyForEvent()`, `hasFestival()` and the data behind them in the consumer.

Reconstructing (1) from the parsha item does not work in general. Shabbat Shuva's own Haftarah is `Hosea 14:2-10; Micah 7:18-20; Joel 2:15-27`, while the parsha carries the two-part `"(with Vayeilech)"` variant.

So `&events=on` does both: it labels each holiday reading with the `desc` of every event that produces it, and appends the readings `getLeyningOnDate()` left out.

```
GET /leyning?cfg=json&date=2026-02-14&events=on
  Mishpatim                        (no desc — it is the parsha reading)
  Shabbat Shekalim   desc: ["Shabbat Shekalim"]      ← added by events=on

GET /leyning?cfg=json&date=2025-12-21&events=on
  Chanukah Day 7 (on Rosh Chodesh) desc: ["Chanukah: 8 Candles", "Rosh Chodesh Tevet"]
```

Readings that belong to no event — weekday, Mincha, Erev Simchat Torah — simply come back without a `desc`, which is the filter the consumer wants anyway. **Without the parameter the response is unchanged.**

## `/converter`: resolve `lg` through `lgToLocale` before rendering

Separate bug found while checking locale handling. `converter.js` mapped `lg` for date formatting but rendered the Hebrew date and the events from the raw `ctx.state.lg`:

```js
ctx.state.lg = q.lg || 's';
const lg = lgToLocale[ctx.state.lg] || ctx.state.lg;  // 'ah' → 'ashkenazi'
ctx.state.locale = localeMap[lg] || 'en';             // used for dayjs + Locale.gettext
…
const lg = ctx.state.lg;                              // back to the raw 'ah'
const hdateStr = hdate.render(lg);
result.events = p.events.map(renameChanukah(p.lg));
```

`@hebcal/hdate`'s own alias table knows only `a`/`h`/`s`, so `lg=ah` — Ashkenazi transliteration plus the Hebrew name in email subject lines — silently produced Sephardic transliteration here, while `/shabbat` honored it because `makeHebcalOptions()` applies `lgToLocale` first:

| `lg` | `/converter` before | `/converter` after | `/shabbat` |
|---|---|---|---|
| `a` | Parshas Chayei Sara | Parshas Chayei Sara | Parshas Chayei Sara |
| `ah` | Parashat Chayei Sara | **Parshas Chayei Sara** | Parshas Chayei Sara |
| `s`, `sh`, `h`, `fr`, … | unchanged | unchanged | unchanged |

Resolving once, up front, means everything downstream renders in the locale both routes agree on. The language menus read `q.lg` rather than `ctx.state.lg`, so they still round-trip the value the reader picked.

## Testing

`npm test` — 600 passed, 8 skipped. New cases cover `events=on` (labelling, the added special-Shabbat reading, multiple events sharing one reading, and that weekday/Mincha readings stay unlabelled), the unchanged default response, and `/converter` across `s`/`a`/`sh`/`ah`/`h`/`fr`.

Also validated by running this branch against the Go port side by side: 13,152 `/shabbat?cfg=json` responses across six years and six locations, plus 3,288 more across all 18 supported `lg` values, with no difference in any `leyning` object.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QKp3oABEUBVTAR4K7MYGHY

---
_Generated by [Claude Code](https://claude.ai/code/session_01QKp3oABEUBVTAR4K7MYGHY)_